### PR TITLE
Fix monochrome displays using ssd1306 and sh1107

### DIFF
--- a/components/lvgl_esp32_drivers/lvgl_tft/sh1107.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/sh1107.c
@@ -165,7 +165,12 @@ void sh1107_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * colo
 #else 
         ptr = color_map + i * CONFIG_LVGL_DISPLAY_WIDTH;
 #endif
-        sh1107_send_color( (void *) ptr, size);
+        if(i != row2){
+			sh1107_send_data( (void *) ptr, size);
+		} else {
+			// complete sending data by sh1107_send_color() and thus call lv_flush_ready()
+			sh1107_send_color( (void *) ptr, size);
+		}
     }
 }
 

--- a/components/lvgl_esp32_drivers/lvgl_tft/sh1107.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/sh1107.c
@@ -171,8 +171,14 @@ void sh1107_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * colo
 
 void sh1107_rounder(struct _disp_drv_t * disp_drv, lv_area_t *area)
 {
-    area->y1 = (area->y1 & (~0x7));
-    area->y2 = (area->y2 & (~0x7)) + 7;
+    // area->y1 = (area->y1 & (~0x7));
+    // area->y2 = (area->y2 & (~0x7)) + 7;
+
+	// workaround: always send complete size display buffer
+	area->x1 = 0;
+	area->y1 = 0;
+	area->x2 = CONFIG_LVGL_DISPLAY_WIDTH-1;
+	area->y2 = CONFIG_LVGL_DISPLAY_HEIGHT-1;
 }
 
 void sh1107_sleep_in()

--- a/components/lvgl_esp32_drivers/lvgl_tft/ssd1306.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/ssd1306.c
@@ -202,8 +202,14 @@ void ssd1306_flush(lv_disp_drv_t * disp_drv, const lv_area_t * area, lv_color_t 
 
 void ssd1306_rounder(struct _disp_drv_t * disp_drv, lv_area_t *area)
 {
-  area->y1 = (area->y1 & (~0x7));
-  area->y2 = (area->y2 & (~0x7)) + 7;
+  	// area->y1 = (area->y1 & (~0x7));
+  	// area->y2 = (area->y2 & (~0x7)) + 7;
+
+	// workaround: always send complete size display buffer
+	area->x1 = 0;
+	area->y1 = 0;
+	area->x2 = CONFIG_LVGL_DISPLAY_WIDTH-1;
+	area->y2 = CONFIG_LVGL_DISPLAY_HEIGHT-1;
 }
 
 void ssd1306_sleep_in()

--- a/main/main.c
+++ b/main/main.c
@@ -23,9 +23,6 @@
 /* Littlevgl specific */
 #include "lvgl/lvgl.h"
 #include "lvgl_driver.h"
-#ifdef CONFIG_LVGL_TFT_DISPLAY_MONOCHROME
-#include "lv_theme_mono.h"
-#endif
 #include "lv_examples/lv_apps/demo/demo.h"
 
 /*********************


### PR DESCRIPTION
- Workaround using ssd1306_rounder() and sh1107_rounder() for ssd1306_flush() and sh1107_flush() which needs to be fixed.
- Fixed: lv_flush_ready() is called to early for sh1107
- Remove including lv_theme_mono.h
