### PR TITLE
Added display driver ST7735S  and device M5StickC

### DIFF
--- a/components/lvgl_esp32_drivers/lvgl_tft/Kconfig
+++ b/components/lvgl_esp32_drivers/lvgl_tft/Kconfig
@@ -27,15 +27,19 @@ menu "LittlevGL (LVGL) TFT Display controller"
             select LVGL_TFT_DISPLAY_PROTOCOL_SPI
             select LVGL_TFT_DISPLAY_MONOCHROME
             select LVGL_THEME_MONO
-	config LVGL_PREDEFINED_DISPLAY_ERTFT0356
-	    bool "ER-TFT035-6"
+        config LVGL_PREDEFINED_DISPLAY_M5STICKC
+            bool "M5StickC"
+            select LVGL_TFT_DISPLAY_CONTROLLER_ST7735S
+            select LVGL_TFT_DISPLAY_PROTOCOL_SPI
+        config LVGL_PREDEFINED_DISPLAY_ERTFT0356
+	          bool "ER-TFT035-6"
             select LVGL_TFT_DISPLAY_CONTROLLER_ILI9488
             select LVGL_TFT_DISPLAY_PROTOCOL_SPI
-	config LVGL_PREDEFINED_DISPLAY_ADA_FEATHERWING
+	    config LVGL_PREDEFINED_DISPLAY_ADA_FEATHERWING
             bool "Adafruit 3.5 Featherwing"
             select LVGL_TFT_DISPLAY_CONTROLLER_HX8357
             select LVGL_TFT_DISPLAY_PROTOCOL_SPI
-  	config LVGL_PREDEFINED_DISPLAY_RPI_MPI3501
+  	    config LVGL_PREDEFINED_DISPLAY_RPI_MPI3501
             bool "RPi MPI3501"
             select LVGL_TFT_DISPLAY_CONTROLLER_ILI9486
             select LVGL_TFT_DISPLAY_PROTOCOL_SPI
@@ -77,6 +81,11 @@ menu "LittlevGL (LVGL) TFT Display controller"
         bool
         help
             ST7789 display controller.
+
+    config LVGL_TFT_DISPLAY_CONTROLLER_ST7735S
+        bool
+        help
+            ST7735S display controller.
 
     config LVGL_TFT_DISPLAY_CONTROLLER_HX8357
         bool
@@ -165,8 +174,12 @@ menu "LittlevGL (LVGL) TFT Display controller"
 	    bool "ST7789"
             select LVGL_TFT_DISPLAY_CONTROLLER_ST7789
             select LVGL_TFT_DISPLAY_PROTOCOL_SPI
-	config LVGL_TFT_DISPLAY_USER_CONTROLLER_HX8357
-	    bool "HX8357"
+  config LVGL_TFT_DISPLAY_USER_CONTROLLER_ST7735S
+		        bool "ST7735S"
+            select LVGL_TFT_DISPLAY_CONTROLLER_ST7735S
+            select LVGL_TFT_DISPLAY_PROTOCOL_SPI
+  config LVGL_TFT_DISPLAY_USER_CONTROLLER_HX8357
+		        bool "HX8357"
             select LVGL_TFT_DISPLAY_CONTROLLER_HX8357
             select LVGL_TFT_DISPLAY_PROTOCOL_SPI
 	config LVGL_TFT_DISPLAY_USER_CONTROLLER_SH1107
@@ -198,9 +211,9 @@ menu "LittlevGL (LVGL) TFT Display controller"
 	endchoice
 
     choice
-		prompt "Display orientation" if LVGL_PREDEFINED_DISPLAY_M5STACK || LVGL_PREDEFINED_DISPLAY_M5STICK || \
-            LVGL_PREDEFINED_DISPLAY_WEMOS_LOLIN || LVGL_PREDEFINED_DISPLAY_WROVER4 || \
-            LVGL_PREDEFINED_DISPLAY_RPI_MPI3501 || \
+	    prompt "Display orientation" if LVGL_PREDEFINED_DISPLAY_M5STACK || LVGL_PREDEFINED_DISPLAY_M5STICK || \
+            LVGL_PREDEFINED_DISPLAY_M5STICKC || LVGL_PREDEFINED_DISPLAY_WEMOS_LOLIN || \
+            LVGL_PREDEFINED_DISPLAY_WROVER4 || LVGL_PREDEFINED_DISPLAY_RPI_MPI3501 || \
             LVGL_TFT_DISPLAY_CONTROLLER_ILI9341 || LVGL_TFT_DISPLAY_CONTROLLER_SH1107 || \
             LVGL_TFT_DISPLAY_CONTROLLER_ILI9486 || LVGL_TFT_DISPLAY_CONTROLLER_SSD1306 || \
             LVGL_TFT_DISPLAY_CONTROLLER_ILI9488 || LVGL_TFT_DISPLAY_CONTROLLER_FT81X
@@ -226,18 +239,22 @@ menu "LittlevGL (LVGL) TFT Display controller"
 	    default 480 if LVGL_PREDEFINED_DISPLAY_ERTFT0356 || LVGL_PREDEFINED_DISPLAY_ADA_FEATHERWING
         default 64 if ( LVGL_PREDEFINED_DISPLAY_WEMOS_LOLIN || LVGL_PREDEFINED_DISPLAY_M5STICK ) && LVGL_DISPLAY_ORIENTATION_PORTRAIT
         default 128 if ( LVGL_PREDEFINED_DISPLAY_WEMOS_LOLIN || LVGL_PREDEFINED_DISPLAY_M5STICK ) && LVGL_DISPLAY_ORIENTATION_LANDSCAPE
-		default 800 if LVGL_TFT_DISPLAY_CONTROLLER_FT81X
+        default 80 if LVGL_PREDEFINED_DISPLAY_M5STICKC && LVGL_DISPLAY_ORIENTATION_PORTRAIT
+        default 160 if LVGL_PREDEFINED_DISPLAY_M5STICKC && LVGL_DISPLAY_ORIENTATION_LANDSCAPE
+        default 800 if LVGL_TFT_DISPLAY_CONTROLLER_FT81X
 	    default 320
-
+        
     config LVGL_DISPLAY_HEIGHT
         int "TFT display height in pixels." if LVGL_PREDEFINED_DISPLAY_NONE
         default 320 if ( LVGL_PREDEFINED_DISPLAY_M5STACK || LVGL_PREDEFINED_DISPLAY_WROVER4 ) && LVGL_DISPLAY_ORIENTATION_PORTRAIT
         default 240 if ( LVGL_PREDEFINED_DISPLAY_M5STACK || LVGL_PREDEFINED_DISPLAY_WROVER4 ) && LVGL_DISPLAY_ORIENTATION_LANDSCAPE
-	    default 320 if LVGL_PREDEFINED_DISPLAY_ERTFT0356 || LVGL_PREDEFINED_DISPLAY_ADA_FEATHERWING
+        default 320 if LVGL_PREDEFINED_DISPLAY_ERTFT0356 || LVGL_PREDEFINED_DISPLAY_ADA_FEATHERWING
         default 128 if ( LVGL_PREDEFINED_DISPLAY_WEMOS_LOLIN || LVGL_PREDEFINED_DISPLAY_M5STICK ) && LVGL_DISPLAY_ORIENTATION_PORTRAIT
         default 64 if ( LVGL_PREDEFINED_DISPLAY_WEMOS_LOLIN || LVGL_PREDEFINED_DISPLAY_M5STICK ) && LVGL_DISPLAY_ORIENTATION_LANDSCAPE
-		default 480 if LVGL_TFT_DISPLAY_CONTROLLER_FT81X
-        default 240
+        default 160 if LVGL_PREDEFINED_DISPLAY_M5STICKC && LVGL_DISPLAY_ORIENTATION_PORTRAIT
+        default 80 if LVGL_PREDEFINED_DISPLAY_M5STICKC && LVGL_DISPLAY_ORIENTATION_LANDSCAPE
+        default 480 if LVGL_TFT_DISPLAY_CONTROLLER_FT81X
+    default 240
 
     config LVGL_INVERT_DISPLAY
         bool "IN DEPRECATION - Invert display."
@@ -245,6 +262,30 @@ menu "LittlevGL (LVGL) TFT Display controller"
         help
             If text is backwards on your display, try enabling this.
     
+    config LVGL_M5STICKC_HANDLE_AXP192
+        bool "Handle Backlight and TFT power for M5StickC using AXP192."
+        default y if LVGL_PREDEFINED_DISPLAY_M5STICKC
+        help
+            Display and TFT power supply on M5StickC is controlled using an AXP192 Power Mangerment IC. 
+            Select yes if you want to enable TFT IC (LDO3) and backlight power using AXP192 by LVGL, or select no if you want to take care of
+            power management in your own code.
+
+    config LVGL_AXP192_PIN_SDA
+        int "GPIO for AXP192 I2C SDA" if LVGL_M5STICKC_HANDLE_AXP192
+        range 0 39
+        default 21 if LVGL_PREDEFINED_DISPLAY_M5STICKC
+        default 21
+        help
+            Configure the AXP192 I2C SDA pin here.
+
+    config LVGL_AXP192_PIN_SCL
+        int "GPIO for AXP192 I2C SCL" if LVGL_M5STICKC_HANDLE_AXP192
+        range 0 39
+        default 22 if LVGL_PREDEFINED_DISPLAY_M5STICKC
+        default 22
+        help
+            Configure the AXP192 I2C SDA pin here.
+
     config LVGL_INVERT_COLORS
         bool "Invert colors in display" if LVGL_TFT_DISPLAY_CONTROLLER_ILI9341
         default y if LVGL_PREDEFINED_DISPLAY_M5STACK
@@ -281,6 +322,7 @@ menu "LittlevGL (LVGL) TFT Display controller"
             range 0 39
             default 23 if LVGL_PREDEFINED_DISPLAY_WROVER4
             default 23 if LVGL_PREDEFINED_DISPLAY_M5STACK || LVGL_PREDEFINED_DISPLAY_M5STICK
+            default 15 if LVGL_PREDEFINED_DISPLAY_M5STICKC
             default 18 if LVGL_PREDEFINED_DISPLAY_ADA_FEATHERWING
 		    default 23 if LVGL_PREDEFINED_PINS_TKOALA
             default 13
@@ -301,6 +343,7 @@ menu "LittlevGL (LVGL) TFT Display controller"
             int "GPIO for CLK (SCK / Serial Clock)" if LVGL_TFT_DISPLAY_PROTOCOL_SPI
             range 0 39
             default 18 if LVGL_PREDEFINED_DISPLAY_M5STACK || LVGL_PREDEFINED_DISPLAY_M5STICK
+            default 13 if LVGL_PREDEFINED_DISPLAY_M5STICKC
             default 19 if LVGL_PREDEFINED_DISPLAY_WROVER4
             default 5 if LVGL_PREDEFINED_DISPLAY_ADA_FEATHERWING
             default 18 if LVGL_PREDEFINED_PINS_TKOALA
@@ -314,6 +357,7 @@ menu "LittlevGL (LVGL) TFT Display controller"
             range 0 39
             default 5 if LVGL_PREDEFINED_PINS_38V1
             default 14 if LVGL_PREDEFINED_DISPLAY_M5STACK || LVGL_PREDEFINED_DISPLAY_M5STICK
+            default 5 if LVGL_PREDEFINED_DISPLAY_M5STICKC
             default 22 if LVGL_PREDEFINED_DISPLAY_WROVER4
             default 15 if LVGL_PREDEFINED_DISPLAY_ADA_FEATHERWING
             default 5  if LVGL_PREDEFINED_PINS_TKOALA
@@ -328,6 +372,7 @@ menu "LittlevGL (LVGL) TFT Display controller"
             default 19 if LVGL_PREDEFINED_PINS_38V1
             default 17 if LVGL_PREDEFINED_PINS_38V4
             default 27 if LVGL_PREDEFINED_DISPLAY_M5STACK || LVGL_PREDEFINED_DISPLAY_M5STICK
+            default 23 if LVGL_PREDEFINED_DISPLAY_M5STICKC
             default 21 if LVGL_PREDEFINED_DISPLAY_WROVER4
             default 33 if LVGL_PREDEFINED_DISPLAY_ADA_FEATHERWING
             default 0  if LVGL_PREDEFINED_PINS_TKOALA
@@ -342,6 +387,7 @@ menu "LittlevGL (LVGL) TFT Display controller"
             default 18 if LVGL_PREDEFINED_PINS_38V1
             default 25 if LVGL_PREDEFINED_PINS_38V4
             default 33 if LVGL_PREDEFINED_DISPLAY_M5STACK || LVGL_PREDEFINED_DISPLAY_M5STICK
+            default 18 if LVGL_PREDEFINED_DISPLAY_M5STICKC
             default 18 if LVGL_PREDEFINED_DISPLAY_WROVER4
             default 4 if LVGL_PREDEFINED_DISPLAY_ADA_FEATHERWING
             default 15 if LVGL_PREDEFINED_PINS_TKOALA

--- a/components/lvgl_esp32_drivers/lvgl_tft/disp_driver.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/disp_driver.c
@@ -22,6 +22,8 @@ void disp_driver_init(bool init_spi)
     ili9488_init();
 #elif defined CONFIG_LVGL_TFT_DISPLAY_CONTROLLER_ST7789
     st7789_init();
+#elif defined CONFIG_LVGL_TFT_DISPLAY_CONTROLLER_ST7735S
+    st7735s_init();
 #elif defined CONFIG_LVGL_TFT_DISPLAY_CONTROLLER_HX8357
 	 hx8357_init(HX8357D);
 #elif defined CONFIG_LVGL_TFT_DISPLAY_CONTROLLER_ILI9486 
@@ -43,6 +45,8 @@ void disp_driver_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t *
     ili9488_flush(drv, area, color_map);
 #elif defined CONFIG_LVGL_TFT_DISPLAY_CONTROLLER_ST7789
     st7789_flush(drv, area, color_map);
+#elif defined CONFIG_LVGL_TFT_DISPLAY_CONTROLLER_ST7735S
+    st7735s_flush(drv, area, color_map);
 #elif defined CONFIG_LVGL_TFT_DISPLAY_CONTROLLER_HX8357
 	hx8357_flush(drv, area, color_map);
 #elif defined CONFIG_LVGL_TFT_DISPLAY_CONTROLLER_ILI9486

--- a/components/lvgl_esp32_drivers/lvgl_tft/disp_driver.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/disp_driver.h
@@ -21,6 +21,8 @@ extern "C" {
 #include "ili9488.h"
 #elif defined CONFIG_LVGL_TFT_DISPLAY_CONTROLLER_ST7789
 #include "st7789.h"
+#elif defined CONFIG_LVGL_TFT_DISPLAY_CONTROLLER_ST7735S
+#include "st7735s.h"
 #elif defined CONFIG_LVGL_TFT_DISPLAY_CONTROLLER_HX8357
 #include "hx8357.h"
 #elif defined CONFIG_LVGL_TFT_DISPLAY_CONTROLLER_ILI9486

--- a/components/lvgl_esp32_drivers/lvgl_tft/st7735s.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/st7735s.c
@@ -1,0 +1,249 @@
+/**
+ * @file st7735s.c
+ *
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "st7735s.h"
+#include "disp_spi.h"
+#include "driver/i2c.h"
+#include "driver/gpio.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+ #define TAG "ST7735S"
+ #define AXP192_I2C_ADDRESS                    0x34
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/*The LCD needs a bunch of command/argument values to be initialized. They are stored in this struct. */
+typedef struct {
+    uint8_t cmd;
+    uint8_t data[16];
+    uint8_t databytes; //No of data in data; bit 7 = delay after set; 0xFF = end of cmds.
+} lcd_init_cmd_t;
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+static void st7735s_send_cmd(uint8_t cmd);
+static void st7735s_send_data(void * data, uint16_t length);
+static void st7735s_send_color(void * data, uint16_t length);
+static void i2c_master_init();
+static void axp192_write_byte(uint8_t addr, uint8_t data);
+static void axp192_init();
+static void axp192_slep_in();
+static void axp192_slep_out();
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+uint8_t st7735s_portrait_mode = 0;
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+void st7735s_init(void)
+{
+	uint8_t data[1] = { 0 };
+
+#ifdef CONFIG_LVGL_M5STICKC_HANDLE_AXP192
+    i2c_master_init();
+    axp192_init();
+#endif
+
+    lcd_init_cmd_t init_cmds[]={
+		{ST7735_SWRESET, {0}, 0x80},         		// Software reset, 0 args, w/delay 150
+		{ST7735_SLPOUT, {0}, 0x80},                 // Out of sleep mode, 0 args, w/delay 500
+		{ST7735_FRMCTR1, {0x01, 0x2C, 0x2D}, 3},    // Frame rate ctrl - normal mode, 3 args: Rate = fosc/(1x2+40) * (LINE+2C+2D)
+		{ST7735_FRMCTR2, {0x01, 0x2C, 0x2D}, 3},    // Frame rate control - idle mode, 3 args:Rate = fosc/(1x2+40) * (LINE+2C+2D)
+		{ST7735_FRMCTR3, {0x01, 0x2C, 0x2D,0x01, 0x2C, 0x2D}, 6}, //Frame rate ctrl - partial mode, 6 args:Dot inversion mode. Line inversion mode
+		{ST7735_INVCTR, {0x07}, 1},                 // Display inversion ctrl, 1 arg, no delay:No inversion
+		{ST7735_PWCTR1, {0xA2,0x02, 0x84}, 3},      // Power control, 3 args, no delay:-4.6V AUTO mode
+		{ST7735_PWCTR2, {0xC5}, 1},                 // Power control, 1 arg, no delay:VGH25 = 2.4C VGSEL = -10 VGH = 3 * AVDD
+		{ST7735_PWCTR3, {0x0A, 0x00}, 2},           // Power control, 2 args, no delay: Opamp current small, Boost frequency
+		{ST7735_PWCTR4, {0x8A,0x2A }, 2},           // Power control, 2 args, no delay: BCLK/2, Opamp current small & Medium low
+		{ST7735_PWCTR5, {0x8A, 0xEE}, 2},           // Power control, 2 args, no delay:
+		{ST7735_VMCTR1, {0x0E}, 1},                 // Power control, 1 arg, no delay:
+		{ST7735_INVON, {0}, 0},
+		{ST7735_COLMOD, {0x05}, 1},               	// set color mode, 1 arg, no delay: 16-bit color
+		{ST7735_GMCTRP1, {0x02, 0x1c, 0x07, 0x12,
+			0x37, 0x32, 0x29, 0x2d,
+			0x29, 0x25, 0x2B, 0x39,
+			0x00, 0x01, 0x03, 0x10}, 16},           // 16 args, no delay:
+		{ST7735_GMCTRN1, {0x03, 0x1d, 0x07, 0x06,
+			0x2E, 0x2C, 0x29, 0x2D,
+			0x2E, 0x2E, 0x37, 0x3F,
+			0x00, 0x00, 0x02, 0x10}, 16},           // 16 args, no delay:
+		{ST7735_NORON, {0}, TFT_INIT_DELAY},       	// Normal display on, no args, w/delay 10 ms delay
+		{ST7735_DISPON, {0}, TFT_INIT_DELAY},       // Main screen turn on, no args w/delay 100 ms delay
+		{0, {0}, 0xff}
+    };
+
+	//Initialize non-SPI GPIOs
+	gpio_set_direction(ST7735S_DC, GPIO_MODE_OUTPUT);
+	gpio_set_direction(ST7735S_RST, GPIO_MODE_OUTPUT);
+
+	//Reset the display
+	gpio_set_level(ST7735S_RST, 0);
+	vTaskDelay(100 / portTICK_RATE_MS);
+	gpio_set_level(ST7735S_RST, 1);
+	vTaskDelay(100 / portTICK_RATE_MS);
+
+	ESP_LOGI(TAG, "ST7735S initialization.");
+
+	//Send all the commands
+	uint16_t cmd = 0;
+	while (init_cmds[cmd].databytes!=0xff) {
+		st7735s_send_cmd(init_cmds[cmd].cmd);
+		st7735s_send_data(init_cmds[cmd].data, init_cmds[cmd].databytes&0x1F);
+		if (init_cmds[cmd].databytes & 0x80) {
+			vTaskDelay(100 / portTICK_RATE_MS);
+		}
+		cmd++;
+	}
+
+#if defined CONFIG_LVGL_DISPLAY_ORIENTATION_PORTRAIT
+	st7735s_portrait_mode = 1;
+#else
+	st7735s_portrait_mode = 0;
+#endif
+
+	if(st7735s_portrait_mode){
+		data[0] = ST77XX_MADCTL_MX | ST77XX_MADCTL_MY | ST77XX_MADCTL_RGB;
+	} else {
+		data[0] = ST77XX_MADCTL_MY | ST77XX_MADCTL_MV | ST77XX_MADCTL_RGB;
+	}
+
+    st7735s_send_cmd(ST7735_MADCTL);
+    st7735s_send_data(&data, 1);
+}
+
+void st7735s_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color_map)
+{
+	uint8_t data[4];
+
+	/*Column addresses*/
+	st7735s_send_cmd(0x2A);
+	data[0] = (area->x1 >> 8) & 0xFF;
+	data[1] = (area->x1 & 0xFF) + (st7735s_portrait_mode ? COLSTART : ROWSTART);
+	data[2] = (area->x2 >> 8) & 0xFF;
+	data[3] = (area->x2 & 0xFF) + (st7735s_portrait_mode ? COLSTART : ROWSTART);
+	st7735s_send_data(data, 4);
+
+	/*Page addresses*/
+	st7735s_send_cmd(0x2B);
+	data[0] = (area->y1 >> 8) & 0xFF;
+	data[1] = (area->y1 & 0xFF) + (st7735s_portrait_mode ? ROWSTART : COLSTART);
+	data[2] = (area->y2 >> 8) & 0xFF;
+	data[3] = (area->y2 & 0xFF) + (st7735s_portrait_mode ? ROWSTART : COLSTART);
+	st7735s_send_data(data, 4);
+
+	/*Memory write*/
+	st7735s_send_cmd(0x2C);
+
+	uint32_t size = lv_area_get_width(area) * lv_area_get_height(area);
+	st7735s_send_color((void*)color_map, size * 2);
+}
+
+void st7735s_sleep_in()
+{
+	st7735s_send_cmd(0x10);
+	axp192_slep_in();
+}
+
+void st7735s_sleep_out()
+{
+	axp192_slep_out();
+	st7735s_send_cmd(0x11);
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static void st7735s_send_cmd(uint8_t cmd)
+{
+	disp_wait_for_pending_transactions();
+	gpio_set_level(ST7735S_DC, 0);	 /*Command mode*/
+	disp_spi_send_data(&cmd, 1);
+}
+
+static void st7735s_send_data(void * data, uint16_t length)
+{
+	disp_wait_for_pending_transactions();
+	gpio_set_level(ST7735S_DC, 1);	 /*Data mode*/
+	disp_spi_send_data(data, length);
+}
+
+static void st7735s_send_color(void * data, uint16_t length)
+{
+	disp_wait_for_pending_transactions();
+	gpio_set_level(ST7735S_DC, 1);   /*Data mode*/
+	disp_spi_send_colors(data, length);
+}
+
+static void i2c_master_init()
+{
+	i2c_config_t i2c_config = {
+		.mode               = I2C_MODE_MASTER,
+		.sda_io_num         = AXP192_SDA,
+		.scl_io_num         = AXP192_SCL,
+		.sda_pullup_en      = GPIO_PULLUP_ENABLE,
+		.scl_pullup_en      = GPIO_PULLUP_ENABLE,
+		.master.clk_speed   = 400000
+	};
+	i2c_param_config(I2C_NUM_0, &i2c_config);
+	i2c_driver_install(I2C_NUM_0, I2C_MODE_MASTER, 0, 0, 0);
+}
+
+static void axp192_write_byte(uint8_t addr, uint8_t data)
+{
+	esp_err_t ret;
+	i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+
+	i2c_master_start(cmd);
+	i2c_master_write_byte(cmd, (AXP192_I2C_ADDRESS << 1) | I2C_MASTER_WRITE, true);
+	i2c_master_write_byte(cmd, addr, true);
+	i2c_master_write_byte(cmd, data, true);
+	i2c_master_stop(cmd);
+
+	ret = i2c_master_cmd_begin(I2C_NUM_0, cmd, 10/portTICK_PERIOD_MS);
+	if (ret != ESP_OK) {
+		ESP_LOGE(TAG, "AXP192 send failed. code: 0x%.2X", ret);
+	}
+	i2c_cmd_link_delete(cmd);
+}
+
+static void axp192_init()
+{
+	// information on how to init and use AXP192 ifor M5StickC taken from 
+	// 	https://forum.m5stack.com/topic/1025/m5stickc-turn-off-screen-completely
+
+	axp192_write_byte(0x10, 0xFF);			// OLED_VPP Enable
+	axp192_write_byte(0x28, 0xCC);			// Enable LDO2&LDO3, LED&TFT 3.0V
+	axp192_slep_out();
+}
+
+static void axp192_slep_in()
+{
+	axp192_write_byte(0x12, 0x4b);
+}
+
+static void axp192_slep_out()
+{
+	axp192_write_byte(0x12, 0x4d);
+}

--- a/components/lvgl_esp32_drivers/lvgl_tft/st7735s.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/st7735s.h
@@ -1,0 +1,149 @@
+/**
+ * @file lv_templ.h
+ *
+ */
+
+#ifndef ST7735S_H
+#define ST7735S_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include <stdbool.h>
+#include "lvgl/lvgl.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+// #define DISP_BUF_SIZE   (CONFIG_LVGL_DISPLAY_WIDTH*CONFIG_LVGL_DISPLAY_HEIGHT)
+#define DISP_BUF_SIZE (LV_HOR_RES_MAX * 40)
+
+#define ST7735S_DC   CONFIG_LVGL_DISP_PIN_DC
+#define ST7735S_RST  CONFIG_LVGL_DISP_PIN_RST
+
+#define AXP192_SDA   CONFIG_LVGL_AXP192_PIN_SDA
+#define AXP192_SCL   CONFIG_LVGL_AXP192_PIN_SCL
+
+#if defined (CONFIG_LVGL_DISPLAY_ORIENTATION_PORTRAIT_INVERTED)
+#error "ST7735S always using inverted display, choose LVGL_DISPLAY_ORIENTATION_PORTRAIT for orientation"
+#elif defined (CONFIG_LVGL_DISPLAY_ORIENTATION_LANDSCAPE_INVERTED)
+#error "ST7735S always using inverted display, choose CONFIG_LVGL_DISPLAY_ORIENTATION_LANDSCAPE for orientation"
+#endif
+
+// Defines are taken from
+//      https://raw.githubusercontent.com/m5stack/M5StickC/master/src/utility/ST7735_Defines.h
+// and are modified to fit to the M5StickC device, and are taken from 
+//      https://github.com/adafruit/Adafruit-ST7735-Library
+//
+#define ST7735_GREENTAB160x80 // For 160 x 80 display (BGR, inverted, 26 / 1 offset)
+#define COLSTART            26
+#define ROWSTART            1
+
+// Delay between some initialisation commands
+#define TFT_INIT_DELAY      0x80
+
+#define TFT_NOP             0x00
+#define TFT_SWRST           0x01
+
+#define TFT_CASET           0x2A
+#define TFT_PASET           0x2B
+#define TFT_RAMWR           0x2C
+
+#define TFT_RAMRD           0x2E
+#define TFT_IDXRD           0x00
+
+#define TFT_MADCTL          0x36
+#define TFT_MAD_MY          0x80
+#define TFT_MAD_MX          0x40
+#define TFT_MAD_MV          0x20
+#define TFT_MAD_ML          0x10
+#define TFT_MAD_BGR         0x08
+#define TFT_MAD_MH          0x04
+#define TFT_MAD_RGB         0x00
+
+#define TFT_INVOFF          0x20
+#define TFT_INVON           0x21
+
+// ST7735 specific commands used in init
+#define ST7735_NOP          0x00
+#define ST7735_SWRESET      0x01
+#define ST7735_RDDID        0x04
+#define ST7735_RDDST        0x09
+
+#define ST7735_SLPIN        0x10
+#define ST7735_SLPOUT       0x11
+#define ST7735_PTLON        0x12
+#define ST7735_NORON        0x13
+
+#define ST7735_INVOFF       0x20
+#define ST7735_INVON        0x21
+#define ST7735_DISPOFF      0x28
+#define ST7735_DISPON       0x29
+#define ST7735_CASET        0x2A
+#define ST7735_RASET        0x2B
+#define ST7735_RAMWR        0x2C
+#define ST7735_RAMRD        0x2E
+
+#define ST7735_PTLAR        0x30
+//Add       
+#define ST7735_VSCRDEF      0x33
+#define ST7735_COLMOD       0x3A
+#define ST7735_MADCTL       0x36
+#define ST7735_VSCRSADD     0x37
+
+#define ST7735_FRMCTR1      0xB1
+#define ST7735_FRMCTR2      0xB2
+#define ST7735_FRMCTR3      0xB3
+#define ST7735_INVCTR       0xB4
+#define ST7735_DISSET5      0xB6
+
+#define ST7735_PWCTR1       0xC0
+#define ST7735_PWCTR2       0xC1
+#define ST7735_PWCTR3       0xC2
+#define ST7735_PWCTR4       0xC3
+#define ST7735_PWCTR5       0xC4
+#define ST7735_VMCTR1       0xC5
+
+#define ST7735_RDID1        0xDA
+#define ST7735_RDID2        0xDB
+#define ST7735_RDID3        0xDC
+#define ST7735_RDID4        0xDD
+
+#define ST7735_PWCTR6       0xFC
+
+#define ST7735_GMCTRP1      0xE0
+#define ST7735_GMCTRN1      0xE1
+
+#define ST77XX_MADCTL_MY    0x80
+#define ST77XX_MADCTL_MX    0x40
+#define ST77XX_MADCTL_MV    0x20
+#define ST77XX_MADCTL_ML    0x10
+#define ST77XX_MADCTL_RGB   0x00
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+void st7735s_init(void);
+void st7735s_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color_map);
+void st7735s_enable_backlight(bool backlight);
+void st7735s_sleep_in(void);
+void st7735s_sleep_out(void);
+
+/**********************
+ *      MACROS
+ **********************/
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /*ST7735S_H*/

--- a/main/main.c
+++ b/main/main.c
@@ -81,7 +81,7 @@ void guiTask() {
     disp_drv.buffer = &disp_buf;
     lv_disp_drv_register(&disp_drv);
 
-#if defined CONFIG_LVGL_TFT_DISPLAY_MONOCHROME
+#if defined CONFIG_LVGL_TFT_DISPLAY_MONOCHROME || defined CONFIG_LVGL_TFT_DISPLAY_CONTROLLER_ST7735S
     lv_theme_mono_init(0, NULL);
     lv_theme_set_current( lv_theme_get_mono() );
 #endif
@@ -104,11 +104,19 @@ void guiTask() {
     //On ESP32 it's better to create a periodic task instead of esp_register_freertos_tick_hook
     ESP_ERROR_CHECK(esp_timer_start_periodic(periodic_timer, 10*1000)); //10ms (expressed as microseconds)
 
-#ifndef CONFIG_LVGL_TFT_DISPLAY_MONOCHROME
+#if !defined (CONFIG_LVGL_TFT_DISPLAY_MONOCHROME) && !defined(CONFIG_LVGL_TFT_DISPLAY_CONTROLLER_ST7735S)
     demo_create();
 #else
     /* use a pretty small demo for 128x64 monochrome displays */
     lv_obj_t * scr = lv_disp_get_scr_act(NULL);     /*Get the current screen*/
+
+#if defined(CONFIG_LVGL_TFT_DISPLAY_CONTROLLER_ST7735S)
+    static lv_style_t style_screen;
+    lv_style_copy(&style_screen, &lv_style_plain);
+    style_screen.body.main_color = LV_COLOR_BLACK;
+    style_screen.body.grad_color = LV_COLOR_BLACK;
+    lv_obj_set_style(lv_scr_act(), &style_screen);
+#endif
 
     /*Create a Label on the currently active screen*/
     lv_obj_t * label1 =  lv_label_create(scr, NULL);


### PR DESCRIPTION
- Initial checkin for the SPI display driver ST7735S as used in the M5StickC (2019) device.

- Changed the background in main.c to use a black background for M5StickC for readability.

- Added configurable support for AXP192 power management IC via I2C, which is used in M5StickC (2019) device to control power for, besides others, TFT and display controller.

- Update documentation and added device image