### PR TITLE
lv_printf: expose floating-point configuration option to menuconfig

### DIFF
--- a/components/lvgl/Kconfig
+++ b/components/lvgl/Kconfig
@@ -569,4 +569,10 @@ menu "LVGL configuration"
 	    default 32
     endmenu
 
+    menu "Text Settings"
+        config LVGL_SPRINTF_DISABLE_FLOAT
+            bool "Disable float in built-in (v)snprintf functions"
+            default false
+    endmenu
+
 endmenu

--- a/components/lvgl/lv_conf.h
+++ b/components/lvgl/lv_conf.h
@@ -833,6 +833,11 @@ typedef void * lv_font_user_data_t;
 #  define LV_SPRINTF_INCLUDE <stdio.h>
 #  define lv_snprintf     snprintf
 #  define lv_vsnprintf    vsnprintf
+#else   /*!LV_SPRINTF_CUSTOM*/
+#  ifndef CONFIG_LVGL_SPRINTF_DISABLE_FLOAT
+#    define CONFIG_LVGL_SPRINTF_DISABLE_FLOAT 0
+#  endif
+#  define LV_SPRINTF_DISABLE_FLOAT  CONFIG_LVGL_SPRINTF_DISABLE_FLOAT
 #endif  /*LV_SPRINTF_CUSTOM*/
 
 /*===================


### PR DESCRIPTION
Fix: With v7 the option to configure disabling float in lv_prinf functions is exposed, but not put in lv_conf.h. The option can now be changed with menuconfig without modifying lv_conf.h.