### PR TITLE
Fix: For ST7735 red and blue needs to be swapped

### DIFF
--- a/components/lvgl_esp32_drivers/lvgl_tft/st7735s.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/st7735s.c
@@ -127,9 +127,9 @@ void st7735s_init(void)
 #endif
 
 	if(st7735s_portrait_mode){
-		data[0] = ST77XX_MADCTL_MX | ST77XX_MADCTL_MY | ST77XX_MADCTL_RGB;
+		data[0] = ST77XX_MADCTL_MX | ST77XX_MADCTL_MY | ST77XX_MADCTL_BGR;
 	} else {
-		data[0] = ST77XX_MADCTL_MY | ST77XX_MADCTL_MV | ST77XX_MADCTL_RGB;
+		data[0] = ST77XX_MADCTL_MY | ST77XX_MADCTL_MV | ST77XX_MADCTL_BGR;
 	}
 
     st7735s_send_cmd(ST7735_MADCTL);

--- a/components/lvgl_esp32_drivers/lvgl_tft/st7735s.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/st7735s.h
@@ -123,6 +123,7 @@ extern "C" {
 #define ST77XX_MADCTL_MV    0x20
 #define ST77XX_MADCTL_ML    0x10
 #define ST77XX_MADCTL_RGB   0x00
+#define ST77XX_MADCTL_BGR   0x08
 
 /**********************
  *      TYPEDEFS


### PR DESCRIPTION
Colors are not correct for ST7735, red and blue swapped using ST7735_MADCTL