### PR TITLE
Configure GPIOs pins as GPIO explicitly

### DIFF
--- a/components/lvgl_esp32_drivers/lvgl_tft/GC9A01.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/GC9A01.c
@@ -122,10 +122,13 @@ void GC9A01_init(void)
 #endif
 
 	//Initialize non-SPI GPIOs
+        gpio_pad_select_gpio(GC9A01_DC);
 	gpio_set_direction(GC9A01_DC, GPIO_MODE_OUTPUT);
+        gpio_pad_select_gpio(GC9A01_RST);
 	gpio_set_direction(GC9A01_RST, GPIO_MODE_OUTPUT);
 
 #if GC9A01_ENABLE_BACKLIGHT_CONTROL
+    gpio_pad_select_gpio(GC9A01_BCKL);
     gpio_set_direction(GC9A01_BCKL, GPIO_MODE_OUTPUT);
 #endif
 	//Reset the display

--- a/components/lvgl_esp32_drivers/lvgl_tft/hx8357.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/hx8357.c
@@ -160,10 +160,13 @@ static uint8_t displayType = HX8357D;
 void hx8357_init(void)
 {
 	//Initialize non-SPI GPIOs
+        gpio_pad_select_gpio(HX8357_DC);
 	gpio_set_direction(HX8357_DC, GPIO_MODE_OUTPUT);
+        gpio_pad_select_gpio(HX8357_RST);
 	gpio_set_direction(HX8357_RST, GPIO_MODE_OUTPUT);
 
 #if HX8357_ENABLE_BACKLIGHT_CONTROL
+        gpio_pad_select_gpio(HX8357_BCKL);
 	gpio_set_direction(HX8357_BCKL, GPIO_MODE_OUTPUT);
 #endif
 

--- a/components/lvgl_esp32_drivers/lvgl_tft/il3820.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/il3820.c
@@ -196,8 +196,11 @@ void il3820_init(void)
     uint8_t tmp[3] = {0};
 
     /* Initialize non-SPI GPIOs */
+    gpio_pad_select_gpio(IL3820_DC_PIN);
     gpio_set_direction(IL3820_DC_PIN, GPIO_MODE_OUTPUT);
+    gpio_pad_select_gpio(IL3820_RST_PIN);
     gpio_set_direction(IL3820_RST_PIN, GPIO_MODE_OUTPUT);
+    gpio_pad_select_gpio(IL3820_BUSY_PIN);
     gpio_set_direction(IL3820_BUSY_PIN,  GPIO_MODE_INPUT);
 
     /* Harware reset */

--- a/components/lvgl_esp32_drivers/lvgl_tft/ili9341.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/ili9341.c
@@ -91,10 +91,13 @@ void ili9341_init(void)
 #endif
 
 	//Initialize non-SPI GPIOs
+        gpio_pad_select_gpio(ILI9341_DC);
 	gpio_set_direction(ILI9341_DC, GPIO_MODE_OUTPUT);
+        gpio_pad_select_gpio(ILI9341_RST);
 	gpio_set_direction(ILI9341_RST, GPIO_MODE_OUTPUT);
 
 #if ILI9341_ENABLE_BACKLIGHT_CONTROL
+    gpio_pad_select_gpio(ILI9341_BCKL);
     gpio_set_direction(ILI9341_BCKL, GPIO_MODE_OUTPUT);
 #endif
 	//Reset the display

--- a/components/lvgl_esp32_drivers/lvgl_tft/ili9481.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/ili9481.c
@@ -74,10 +74,13 @@ void ili9481_init(void)
     };
 
     //Initialize non-SPI GPIOs
+    gpio_pad_select_gpio(ILI9481_DC);
     gpio_set_direction(ILI9481_DC, GPIO_MODE_OUTPUT);
+    gpio_pad_select_gpio(ILI9481_RST);
     gpio_set_direction(ILI9481_RST, GPIO_MODE_OUTPUT);
 
 #if ILI9481_ENABLE_BACKLIGHT_CONTROL
+    gpio_pad_select_gpio(ILI9481_BCKL);
     gpio_set_direction(ILI9481_BCKL, GPIO_MODE_OUTPUT);
 #endif
 

--- a/components/lvgl_esp32_drivers/lvgl_tft/ili9486.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/ili9486.c
@@ -76,10 +76,13 @@ void ili9486_init(void)
 #endif
 
 	//Initialize non-SPI GPIOs
+        gpio_pad_select_gpio(ILI9486_DC);
 	gpio_set_direction(ILI9486_DC, GPIO_MODE_OUTPUT);
+        gpio_pad_select_gpio(ILI9486_RST);
 	gpio_set_direction(ILI9486_RST, GPIO_MODE_OUTPUT);
 
 #if ILI9486_ENABLE_BACKLIGHT_CONTROL
+    gpio_pad_select_gpio(ILI9486_BCKL);
     gpio_set_direction(ILI9486_BCKL, GPIO_MODE_OUTPUT);
 #endif
 

--- a/components/lvgl_esp32_drivers/lvgl_tft/ili9488.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/ili9488.c
@@ -76,10 +76,13 @@ void ili9488_init(void)
 	};
 
 	//Initialize non-SPI GPIOs
+        gpio_pad_select_gpio(ILI9488_DC);
 	gpio_set_direction(ILI9488_DC, GPIO_MODE_OUTPUT);
+        gpio_pad_select_gpio(ILI9488_RST);
 	gpio_set_direction(ILI9488_RST, GPIO_MODE_OUTPUT);
 
 #if ILI9488_ENABLE_BACKLIGHT_CONTROL
+        gpio_pad_select_gpio(ILI9488_BCKL);
 	gpio_set_direction(ILI9488_BCKL, GPIO_MODE_OUTPUT);
 #endif
 

--- a/components/lvgl_esp32_drivers/lvgl_tft/ra8875.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/ra8875.c
@@ -159,8 +159,10 @@ void ra8875_init(void)
 #endif
 
     // Initialize non-SPI GPIOs
+    gpio_pad_select_gpio(RA8875_RST);
     gpio_set_direction(RA8875_RST, GPIO_MODE_OUTPUT);
 #ifdef CONFIG_LVGL_DISP_PIN_BCKL
+    gpio_pad_select_gpio(CONFIG_LVGL_DISP_PIN_BCKL);
     gpio_set_direction(CONFIG_LVGL_DISP_PIN_BCKL, GPIO_MODE_OUTPUT);
 #endif
 

--- a/components/lvgl_esp32_drivers/lvgl_tft/sh1107.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/sh1107.c
@@ -92,7 +92,9 @@ void sh1107_init(void)
 	};
 
 	//Initialize non-SPI GPIOs
+        gpio_pad_select_gpio(SH1107_DC);
 	gpio_set_direction(SH1107_DC, GPIO_MODE_OUTPUT);
+        gpio_pad_select_gpio(SH1107_RST);
 	gpio_set_direction(SH1107_RST, GPIO_MODE_OUTPUT);
 
 	//Reset the display

--- a/components/lvgl_esp32_drivers/lvgl_tft/st7735s.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/st7735s.c
@@ -97,7 +97,9 @@ void st7735s_init(void)
     };
 
 	//Initialize non-SPI GPIOs
+        gpio_pad_select_gpio(ST7735S_DC);
 	gpio_set_direction(ST7735S_DC, GPIO_MODE_OUTPUT);
+        gpio_pad_select_gpio(ST7735S_RST);
 	gpio_set_direction(ST7735S_RST, GPIO_MODE_OUTPUT);
 
 	//Reset the display

--- a/components/lvgl_esp32_drivers/lvgl_tft/st7789.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/st7789.c
@@ -82,10 +82,13 @@ void st7789_init(void)
     };
 
     //Initialize non-SPI GPIOs
+    gpio_pad_select_gpio(ST7789_DC);
     gpio_set_direction(ST7789_DC, GPIO_MODE_OUTPUT);
+    gpio_pad_select_gpio(ST7789_RST);
     gpio_set_direction(ST7789_RST, GPIO_MODE_OUTPUT);
     
 #if ST7789_ENABLE_BACKLIGHT_CONTROL
+    gpio_pad_select_gpio(ST7789_BCKL);
     gpio_set_direction(ST7789_BCKL, GPIO_MODE_OUTPUT);
 #endif
 


### PR DESCRIPTION
Some GPIOs (GPIO32 and GPIO33) need to be explicitly configured as gpios, as we don't know which pin are the users going to choose I think a good solution is to configure all the GPIOs.

Fixes part of #183, another PR will create the predefined display configuration for TTGO Camera Plus board.