### PR TITLE
lv_examples: Add Kconfig to lv_examples and choose an example to run on the menuconfig interface

### DIFF
--- a/components/lv_examples/Kconfig
+++ b/components/lv_examples/Kconfig
@@ -1,0 +1,29 @@
+# Kconfig for lv_examples v7.4.0
+
+menu "lv_examples configuration"
+
+    config LV_EX_PRINTF
+        bool "Enable printf-ing data in demos and examples."
+    
+    choice LV_EX_CHOICE
+        prompt "Select the demo you want to run."
+        default LV_USE_DEMO_WIDGETS
+
+        config LV_USE_DEMO_WIDGETS
+            bool "Show demo widgets."
+
+        config LV_DEMO_WIDGETS_SLIDESHOW
+            bool "Slide demo widgets automatically."
+            depends on LV_USE_DEMO_WIDGETS
+            default y
+
+        config LV_USE_DEMO_KEYPAD_AND_ENCODER
+            bool "Demonstrate the usage of encoder and keyboard."
+
+        config LV_USE_DEMO_BENCHMARK
+            bool "Benchmark your system."
+
+        config LV_USE_DEMO_STRESS
+            bool "Stress test for LVGL."
+    endchoice
+endmenu

--- a/components/lv_examples/lv_ex_conf.h
+++ b/components/lv_examples/lv_ex_conf.h
@@ -16,7 +16,14 @@
 /*******************
  * GENERAL SETTING
  *******************/
-#define LV_EX_PRINTF       CONFIG_LV_EX_PRINTF       /*Enable printf-ing data in demoes and examples*/
+
+/* Enable printf-ing data in demoes and examples */
+#ifdef CONFIG_LV_EX_PRINTF
+#define LV_EX_PRINTF       1
+#else
+#define LV_EX_PRINTF       0
+#endif
+
 #define LV_EX_KEYBOARD     0       /*Add PC keyboard support to some examples (`lv_drivers` repository is required)*/
 #define LV_EX_MOUSEWHEEL   0       /*Add 'encoder' (mouse wheel) support to some examples (`lv_drivers` repository is required)*/
 
@@ -25,22 +32,44 @@
  *********************/
 
 /*Show some widget*/
-#define LV_USE_DEMO_WIDGETS        CONFIG_LV_USE_DEMO_WIDGETS
+#ifdef CONFIG_LV_USE_DEMO_WIDGETS
+#define LV_USE_DEMO_WIDGETS        1
+#else
+#define LV_USE_DEMO_WIDGETS        0
+#endif
+
 #if LV_USE_DEMO_WIDGETS
-#define LV_DEMO_WIDGETS_SLIDESHOW  CONFIG_LV_DEMO_WIDGETS_SLIDESHOW
+#ifdef CONFIG_LV_DEMO_WIDGETS_SLIDESHOW
+#define LV_DEMO_WIDGETS_SLIDESHOW   1
+#else
+#define LV_DEMO_WIDGETS_SLIDESHOW   0
+#endif
 #endif
 
 /*Printer demo, optimized for 800x480*/
 #define LV_USE_DEMO_PRINTER     0
 
 /*Demonstrate the usage of encoder and keyboard*/
-#define LV_USE_DEMO_KEYPAD_AND_ENCODER     CONFIG_LV_USE_DEMO_KEYPAD_AND_ENCODER
+#ifdef CONFIG_LV_USE_DEMO_KEYPAD_AND_ENCODER
+#define LV_USE_DEMO_KEYPAD_AND_ENCODER  1
+#else
+#define LV_USE_DEMO_KEYPAD_AND_ENCODER  0
+#endif
 
 /*Benchmark your system*/
-#define LV_USE_DEMO_BENCHMARK   CONFIG_LV_USE_DEMO_BECHMARK
+#ifdef CONFIG_LV_USE_DEMO_BENCHMARK
+#define LV_USE_DEMO_BENCHMARK   1
+#else
+#define LV_USE_DEMO_BENCHMARK   0
+#endif
 
 /*Stress test for LVGL*/
-#define LV_USE_DEMO_STRESS      CONFIG_LV_USE_DEMO_STRESS
+#ifdef CONFIG_LV_USE_DEMO_STRESS
+#define LV_USE_DEMO_STRESS  1 
+#else
+#define LV_USE_DEMO_STRESS  0 
+
+#endif
 
 #endif /*LV_EX_CONF_H*/
 

--- a/components/lv_examples/lv_ex_conf.h
+++ b/components/lv_examples/lv_ex_conf.h
@@ -16,7 +16,7 @@
 /*******************
  * GENERAL SETTING
  *******************/
-#define LV_EX_PRINTF       1       /*Enable printf-ing data in demoes and examples*/
+#define LV_EX_PRINTF       CONFIG_LV_EX_PRINTF       /*Enable printf-ing data in demoes and examples*/
 #define LV_EX_KEYBOARD     0       /*Add PC keyboard support to some examples (`lv_drivers` repository is required)*/
 #define LV_EX_MOUSEWHEEL   0       /*Add 'encoder' (mouse wheel) support to some examples (`lv_drivers` repository is required)*/
 
@@ -25,22 +25,22 @@
  *********************/
 
 /*Show some widget*/
-#define LV_USE_DEMO_WIDGETS        1
+#define LV_USE_DEMO_WIDGETS        CONFIG_LV_USE_DEMO_WIDGETS
 #if LV_USE_DEMO_WIDGETS
-#define LV_DEMO_WIDGETS_SLIDESHOW  1
+#define LV_DEMO_WIDGETS_SLIDESHOW  CONFIG_LV_DEMO_WIDGETS_SLIDESHOW
 #endif
 
 /*Printer demo, optimized for 800x480*/
 #define LV_USE_DEMO_PRINTER     0
 
 /*Demonstrate the usage of encoder and keyboard*/
-#define LV_USE_DEMO_KEYPAD_AND_ENCODER     0
+#define LV_USE_DEMO_KEYPAD_AND_ENCODER     CONFIG_LV_USE_DEMO_KEYPAD_AND_ENCODER
 
 /*Benchmark your system*/
-#define LV_USE_DEMO_BENCHMARK   0
+#define LV_USE_DEMO_BENCHMARK   CONFIG_LV_USE_DEMO_BECHMARK
 
 /*Stress test for LVGL*/
-#define LV_USE_DEMO_STRESS      0
+#define LV_USE_DEMO_STRESS      CONFIG_LV_USE_DEMO_STRESS
 
 #endif /*LV_EX_CONF_H*/
 

--- a/main/main.c
+++ b/main/main.c
@@ -28,7 +28,7 @@
     #if defined CONFIG_LV_USE_DEMO_WIDGETS
         #include "lv_examples/src/lv_demo_widgets/lv_demo_widgets.h"
     #elif defined CONFIG_LV_USE_DEMO_KEYPAD_AND_ENCODER
-        #include "lv_examples/src/lv_demo_keypad_and_encoder/lv_demo_keyoad_and_encoder.h"
+        #include "lv_examples/src/lv_demo_keypad_and_encoder/lv_demo_keypad_and_encoder.h"
     #elif defined CONFIG_LV_USE_DEMO_BENCHMARK
         #include "lv_examples/src/lv_demo_benchmark/lv_demo_benchmark.h"
     #elif defined CONFIG_LV_USE_DEMO_STRESS

--- a/main/main.c
+++ b/main/main.c
@@ -27,11 +27,11 @@
 #ifndef CONFIG_LVGL_TFT_DISPLAY_MONOCHROME
     #if defined CONFIG_LV_USE_DEMO_WIDGETS
         #include "lv_examples/src/lv_demo_widgets/lv_demo_widgets.h"
-    #elif defined CONFIG_LV_DEMO_KEYPAD_AND_ENCODER
+    #elif defined CONFIG_LV_USE_DEMO_KEYPAD_AND_ENCODER
         #include "lv_examples/src/lv_demo_keypad_and_encoder/lv_demo_keyoad_and_encoder.h"
-    #elif defined CONFIG_LV_DEMO_BENCHMARK
+    #elif defined CONFIG_LV_USE_DEMO_BENCHMARK
         #include "lv_examples/src/lv_demo_benchmark/lv_demo_benchmark.h"
-    #elif defined CONFIG_LV_DEMO_STRESS
+    #elif defined CONFIG_LV_USE_DEMO_STRESS
         #include "lv_examples/src/lv_demo_stress/lv_demo_stress.h"
     #else
         #error "No demo application selected."
@@ -178,11 +178,11 @@ static void create_demo_application(void)
 
     #if defined CONFIG_LV_USE_DEMO_WIDGETS
         lv_demo_widgets();
-    #elif defined CONFIG_LV_DEMO_KEYPAD_AND_ENCODER
+    #elif defined CONFIG_LV_USE_DEMO_KEYPAD_AND_ENCODER
         lv_demo_keypad_encoder();
-    #elif defined CONFIG_LV_DEMO_BENCHMARK
+    #elif defined CONFIG_LV_USE_DEMO_BENCHMARK
         lv_demo_benchmark();
-    #elif defined CONFIG_LV_DEMO_STRESS
+    #elif defined CONFIG_LV_USE_DEMO_STRESS
         lv_demo_stress();
     #else
         #error "No demo application selected."

--- a/main/main.c
+++ b/main/main.c
@@ -25,7 +25,17 @@
 #include "lvgl_helpers.h"
 
 #ifndef CONFIG_LVGL_TFT_DISPLAY_MONOCHROME
-#include "lv_examples/src/lv_demo_widgets/lv_demo_widgets.h"
+    #if defined CONFIG_LV_USE_DEMO_WIDGETS
+        #include "lv_examples/src/lv_demo_widgets/lv_demo_widgets.h"
+    #elif defined CONFIG_LV_DEMO_KEYPAD_AND_ENCODER
+        #include "lv_examples/src/lv_demo_keypad_and_encoder/lv_demo_keyoad_and_encoder.h"
+    #elif defined CONFIG_LV_DEMO_BENCHMARK
+        #include "lv_examples/src/lv_demo_benchmark/lv_demo_benchmark.h"
+    #elif defined CONFIG_LV_DEMO_STRESS
+        #include "lv_examples/src/lv_demo_stress/lv_demo_stress.h"
+    #else
+        #error "No demo application selected."
+    #endif
 #endif
 
 /*********************
@@ -164,8 +174,19 @@ static void create_demo_application(void)
      * 0, 0 at the end means an x, y offset after alignment*/
     lv_obj_align(label1, NULL, LV_ALIGN_CENTER, 0, 0);
 #else
-    /* TODO: Otherwise we show the selected demo */
-    lv_demo_widgets();
+    /* Otherwise we show the selected demo */
+
+    #if defined CONFIG_LV_USE_DEMO_WIDGETS
+        lv_demo_widgets();
+    #elif defined CONFIG_LV_DEMO_KEYPAD_AND_ENCODER
+        lv_demo_keypad_encoder();
+    #elif defined CONFIG_LV_DEMO_BENCHMARK
+        lv_demo_benchmark();
+    #elif defined CONFIG_LV_DEMO_STRESS
+        lv_demo_stress();
+    #else
+        #error "No demo application selected."
+    #endif
 #endif
 }
 


### PR DESCRIPTION
New try with the updated `lv_examples`, decided to leave the following options out of the menuconfig:
```
#define LV_EX_KEYBOARD     0       /*Add PC keyboard support to some examples (`lv_drivers` repository is required)*/
#define LV_EX_MOUSEWHEEL   0       /*Add 'encoder' (mouse wheel) support to some examples (`lv_drivers` repository is required)*/

/*Printer demo, optimized for 800x480*/
#define LV_USE_DEMO_PRINTER     0
```
because they are not intended to be used on ESP32, what do you think @kisvegabor.