### PR TITLE
Switch to using a pool of DMA transactions for reduced latency

### DIFF
--- a/components/lvgl_esp32_drivers/lvgl_helpers.c
+++ b/components/lvgl_esp32_drivers/lvgl_helpers.c
@@ -207,8 +207,9 @@ bool lvgl_spi_driver_init(int host,
     };
 
     ESP_LOGI(TAG, "Configuring SPI host %s (%d)", spi_names[host], host);
-    ESP_LOGI(TAG, "MISO pin: %d, MOSI pin: %d, SCLK pin: %d",
-        miso_pin, mosi_pin, sclk_pin);
+    ESP_LOGI(TAG, "MISO pin: %d, MOSI pin: %d, SCLK pin: %d, IO2/WP pin: %d, IO3/HD pin: %d",
+        miso_pin, mosi_pin, sclk_pin, quadwp_pin, quadhd_pin);
+
     ESP_LOGI(TAG, "Max transfer size: %d (bytes)", max_transfer_sz);
 
     spi_bus_config_t buscfg = {

--- a/components/lvgl_esp32_drivers/lvgl_tft/disp_spi.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/disp_spi.c
@@ -30,6 +30,15 @@
 /*********************
  *      DEFINES
  *********************/
+#define SPI_TRANSACTION_POOL_SIZE 50	/* maximum number of DMA transactions simultaneously in-flight */
+
+/* DMA Transactions to reserve before queueing additional DMA transactions. A 1/10th seems to be a good balance. Too many (or all) and it will increase latency. */
+#define SPI_TRANSACTION_POOL_RESERVE_PERCENTAGE 10
+#if SPI_TRANSACTION_POOL_SIZE >= SPI_TRANSACTION_POOL_RESERVE_PERCENTAGE
+#define SPI_TRANSACTION_POOL_RESERVE (SPI_TRANSACTION_POOL_SIZE / SPI_TRANSACTION_POOL_RESERVE_PERCENTAGE)	
+#else
+#define SPI_TRANSACTION_POOL_RESERVE 1	/* defines minimum size */
+#endif
 
 /**********************
  *      TYPEDEFS
@@ -45,7 +54,7 @@ static void IRAM_ATTR spi_ready (spi_transaction_t *trans);
  **********************/
 static spi_host_device_t spi_host;
 static spi_device_handle_t spi;
-static volatile uint8_t spi_pending_trans = 0;
+static QueueHandle_t TransactionPool = NULL;
 static transaction_cb_t chained_post_cb;
 
 /**********************
@@ -80,7 +89,7 @@ void disp_spi_add_device_with_speed(spi_host_device_t host, int clock_speed_hz)
         .mode = SPI_TFT_SPI_MODE,
         .spics_io_num=DISP_SPI_CS,              // CS pin
         .input_delay_ns=DISP_SPI_INPUT_DELAY_NS,
-        .queue_size=1,
+        .queue_size=SPI_TRANSACTION_POOL_SIZE,
         .pre_cb=NULL,
         .post_cb=NULL,
 #if defined(DISP_SPI_HALF_DUPLEX)
@@ -95,6 +104,19 @@ void disp_spi_add_device_with_speed(spi_host_device_t host, int clock_speed_hz)
     };
 
     disp_spi_add_device_config(host, &devcfg);
+
+	/* create the transaction pool and fill it with ptrs to spi_transaction_ext_t to reuse */
+	if(TransactionPool == NULL) {
+		TransactionPool = xQueueCreate(SPI_TRANSACTION_POOL_SIZE, sizeof(spi_transaction_ext_t*));
+		assert(TransactionPool != NULL);
+		for (size_t i = 0; i < SPI_TRANSACTION_POOL_SIZE; i++)
+		{
+			spi_transaction_ext_t* pTransaction = (spi_transaction_ext_t*)heap_caps_malloc(sizeof(spi_transaction_ext_t), MALLOC_CAP_DMA);
+			assert(pTransaction != NULL);
+			memset(pTransaction, 0, sizeof(spi_transaction_ext_t));
+			xQueueSend(TransactionPool, &pTransaction, portMAX_DELAY);
+		}
+	}
 }
 
 void disp_spi_change_device_speed(int clock_speed_hz)
@@ -123,9 +145,6 @@ void disp_spi_transaction(const uint8_t *data, size_t length,
     if (0 == length) {
         return;
     }
-
-    /* Wait for previous pending transaction results */
-    disp_wait_for_pending_transactions();
 
     spi_transaction_ext_t t = {0};
 
@@ -187,15 +206,28 @@ void disp_spi_transaction(const uint8_t *data, size_t length,
 
     /* Poll/Complete/Queue transaction */
     if (flags & DISP_SPI_SEND_POLLING) {
+		disp_wait_for_pending_transactions();	/* before polling, all previous pending transactions need to be serviced */
         spi_device_polling_transmit(spi, (spi_transaction_t *) &t);
     } else if (flags & DISP_SPI_SEND_SYNCHRONOUS) {
+		disp_wait_for_pending_transactions();	/* before synchronous queueing, all previous pending transactions need to be serviced */
         spi_device_transmit(spi, (spi_transaction_t *) &t);
     } else {
-        static spi_transaction_ext_t queuedt;
-        memcpy(&queuedt, &t, sizeof t);
-        spi_pending_trans++;
-        if (spi_device_queue_trans(spi, (spi_transaction_t *) &queuedt, portMAX_DELAY) != ESP_OK) {
-            spi_pending_trans--; /* Clear wait state */
+		
+		/* if necessary, ensure we can queue new transactions by servicing some previous transactions */
+		if(uxQueueMessagesWaiting(TransactionPool) == 0) {
+			spi_transaction_t *presult;
+			while(uxQueueMessagesWaiting(TransactionPool) < SPI_TRANSACTION_POOL_RESERVE) {
+				if (spi_device_get_trans_result(spi, &presult, 1) == ESP_OK) {
+					xQueueSend(TransactionPool, &presult, portMAX_DELAY);	/* back to the pool to be reused */
+				}
+			}
+		}
+
+		spi_transaction_ext_t *pTransaction = NULL;
+		xQueueReceive(TransactionPool, &pTransaction, portMAX_DELAY);
+        memcpy(pTransaction, &t, sizeof(t));
+        if (spi_device_queue_trans(spi, (spi_transaction_t *) pTransaction, portMAX_DELAY) != ESP_OK) {
+			xQueueSend(TransactionPool, &pTransaction, portMAX_DELAY);	/* send failed transaction back to the pool to be reused */
         }
     }
 }
@@ -205,9 +237,9 @@ void disp_wait_for_pending_transactions(void)
 {
     spi_transaction_t *presult;
 
-    while (spi_pending_trans) {
-        if (spi_device_get_trans_result(spi, &presult, portMAX_DELAY) == ESP_OK) {
-            spi_pending_trans--;
+	while(uxQueueMessagesWaiting(TransactionPool) < SPI_TRANSACTION_POOL_SIZE) {	/* service until the transaction reuse pool is full again */
+        if (spi_device_get_trans_result(spi, &presult, 1) == ESP_OK) {
+			xQueueSend(TransactionPool, &presult, portMAX_DELAY);
         }
     }
 }


### PR DESCRIPTION
This update switches SPI displays to used a pool of spi_transaction_ext_t structures for DMA transactions and resolves #203. It reduces DMA transaction latency and thus increases overall transfer throughput. This is completely transparent to all existing drivers but for those that burst multiple DMA requests (such as the FT81x, il3820, jd79653a, uc8151d, etc...) it can have a really big impact on overall display responsiveness and animation speeds. It also better supports LVGL's dual buffer mechanism by making the SPI thread wait less.

This is enabled for all existing display drivers but the old behavior can be re-enabled by setting SPI_TRANSACTION_POOL_SIZE to 1. That effectively reverts to the old behavior of sending 1 transactions and a time and waiting for it to complete before sending more. I don't think this is necessary though as this change only really reduces the latency between DMA requests when bursting data and existing drivers should not care (or notice). 

I also have some more detailed notes on the design of the transaction pool but I'm not sure where to put them in this project. It's about 1/2 a page of so in length and just describes some design decisions, nuances, etc...