### PR TITLE
XPT2046: Abstract the press detection

### DIFF
--- a/components/lvgl_esp32_drivers/lvgl_touch/Kconfig
+++ b/components/lvgl_esp32_drivers/lvgl_touch/Kconfig
@@ -128,6 +128,7 @@ menu "LVGL Touch controller"
 
         config LV_TOUCH_PIN_IRQ
             int "GPIO for IRQ (Interrupt Request)"
+            depends on LV_TOUCH_DETECTION_IRQ_SIGNAL
 	    range 0 39	
             default 27 if LV_PREDEFINED_PINS_38V4
             default 25
@@ -137,6 +138,28 @@ menu "LVGL Touch controller"
     
     menu "Touchpanel Configuration (XPT2046)"
         depends on LV_TOUCH_CONTROLLER_XPT2046
+
+        choice
+            prompt "Touch detection method."
+            default LV_TOUCH_DETECTION_IRQ_SIGNAL
+            help
+                Select between detecting user touching the display
+                based on the IRQ signal or based on Z coordinate reading
+                and comparing it with a threshold.
+
+            config LV_TOUCH_DETECTION_IRQ_SIGNAL
+                bool "Touch detection with IRQ signal."
+            config LV_TOUCH_DETECTION_Z_COORD
+                bool "Touch detection with Z coordinate."
+        endchoice
+        
+        config LV_TOUCH_Z_COORD_THRESHOLD
+            int "Set the Z coordinate threshold for touch detection."
+            depends on LV_TOUCH_DETECTION_Z_COORD
+            range 0 32767
+            default 400
+            help
+                Configure the Z coordinate threshold for touch detection.
 
         config LV_TOUCH_X_MIN
             int

--- a/components/lvgl_esp32_drivers/lvgl_touch/xpt2046.c
+++ b/components/lvgl_esp32_drivers/lvgl_touch/xpt2046.c
@@ -44,7 +44,7 @@ int16_t avg_buf_x[XPT2046_AVG];
 int16_t avg_buf_y[XPT2046_AVG];
 uint8_t avg_last;
 
-#ifdef (CONFIG_LV_TOUCH_DETECTION_Z_COORD)
+#if defined (CONFIG_LV_TOUCH_DETECTION_Z_COORD)
 uint32_t z_coord_pressure_threshold = CONFIG_LV_TOUCH_Z_COORD_THRESHOLD;
 #endif
 
@@ -61,7 +61,7 @@ uint32_t z_coord_pressure_threshold = CONFIG_LV_TOUCH_Z_COORD_THRESHOLD;
  */
 void xpt2046_init(void)
 {
-#ifdef (CONFIG_LV_TOUCH_DETECTION_IRQ_SIGNAL)
+#if defined (CONFIG_LV_TOUCH_DETECTION_IRQ_SIGNAL)
     gpio_config_t irq_config = {
         .pin_bit_mask = BIT64(XPT2046_IRQ),
         .mode = GPIO_MODE_INPUT,
@@ -91,7 +91,9 @@ bool xpt2046_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
     int16_t x = 0;
     int16_t y = 0;
 
-    if (XPT2046_STATE_PRESSED == xpt2046_is_pressed()) {
+    volatile xpt2046_state_t touch_state = xpt2046_is_pressed();
+
+    if (XPT2046_STATE_PRESSED == touch_state) {
 		uint8_t data[2] = {0};
 		
 		tp_spi_read_reg(CMD_X_READ, data, 2);
@@ -200,7 +202,7 @@ static xpt2046_state_t xpt2046_is_pressed(void)
 {
     xpt2046_state_t retval = XPT2046_STATE_IDLE;
 
-#ifdef (CONFIG_LV_TOUCH_DETECTION_IRQ_SIGNAL)
+#if defined (CONFIG_LV_TOUCH_DETECTION_IRQ_SIGNAL)
     uint8_t irq = gpio_get_level(XPT2046_IRQ);
 
     if (irq == 0) {


### PR DESCRIPTION
Related to #206 

TODO:

- [x] Add press detection configuration in touch menuconfig.
- [x] Remove IRQ gpio initialization if Z coordinate press based detection is selected.
- [ ] Validate with different hardware based on XPT2046 controller.