### PR TITLE
Remove drivers symbols on lv_conf.

### DIFF
--- a/components/lvgl/Kconfig
+++ b/components/lvgl/Kconfig
@@ -45,6 +45,10 @@ menu "LVGL configuration"
             displays fall in 4 categories. This is the upper limit for large
             displays.
 
+    config LV_COLOR_16_SWAP
+        bool "Swap the 2 bytes of RGB565 color. Useful if the display has a 8 bit interface (e.g. SPI)."
+        default y
+
     choice LV_COLOR_DEPTH
         prompt "Color depth."
         default LV_COLOR_DEPTH_16

--- a/components/lvgl/Kconfig
+++ b/components/lvgl/Kconfig
@@ -45,6 +45,22 @@ menu "LVGL configuration"
             displays fall in 4 categories. This is the upper limit for large
             displays.
 
+    choice LV_COLOR_DEPTH
+        prompt "Color depth."
+        default LV_COLOR_DEPTH_16
+        help
+            Color depth to be used.
+
+        config LV_COLOR_DEPTH_32
+            bool "32: ARGB8888"
+        config LV_COLOR_DEPTH_16
+            bool "16: RGB565"
+        config LV_COLOR_DEPTH_8
+            bool "8: RGB232"
+        config LV_COLOR_DEPTH_1
+            bool "1: 1 byte per pixel"
+    endchoice
+
     menu "Font usage"
 
         config LV_FONT_FMT_TXT_LARGE

--- a/components/lvgl/lv_conf.h
+++ b/components/lvgl/lv_conf.h
@@ -54,28 +54,10 @@
 
 /* Swap the 2 bytes of RGB565 color.
  * Useful if the display has a 8 bit interface (e.g. SPI)*/
-#if defined CONFIG_LV_TFT_DISPLAY_CONTROLLER_ILI9341
-#define LV_COLOR_16_SWAP   1
-#elif defined CONFIG_LV_TFT_DISPLAY_CONTROLLER_ILI9488
-#define LV_COLOR_16_SWAP   0
-#elif defined CONFIG_LV_TFT_DISPLAY_CONTROLLER_ST7789
-#define LV_COLOR_16_SWAP   1
-#elif defined CONFIG_LV_TFT_DISPLAY_CONTROLLER_ST7735S
-#define LV_COLOR_16_SWAP   1
-#elif defined CONFIG_LV_TFT_DISPLAY_CONTROLLER_HX8357
-#define LV_COLOR_16_SWAP   1
-#elif defined CONFIG_LV_TFT_DISPLAY_CONTROLLER_SH1107
-#define LV_COLOR_16_SWAP   0
-#elif defined CONFIG_LV_TFT_DISPLAY_CONTROLLER_SSD1306
-#define LV_COLOR_16_SWAP   0
-#elif defined CONFIG_LV_TFT_DISPLAY_CONTROLLER_ILI9486
-#define LV_COLOR_16_SWAP   1
-#elif defined CONFIG_LV_TFT_DISPLAY_CONTROLLER_FT81X
-#define LV_COLOR_16_SWAP   0
-#elif defined CONFIG_LV_TFT_DISPLAY_CONTROLLER_RA8875
-#define LV_COLOR_16_SWAP   1
-#elif defined CONFIG_LV_TFT_DISPLAY_CONTROLLER_GC9A01
-#define LV_COLOR_16_SWAP   1
+#ifdef (CONFIG_LV_COLOR_16_SWAP)
+#define LV_COLOR_16_SWAP    1
+#else
+#define LV_COLOR_16_SWAP    0
 #endif
 
 /* 1: Enable screen transparency.

--- a/components/lvgl/lv_conf.h
+++ b/components/lvgl/lv_conf.h
@@ -45,12 +45,7 @@
  * - 16: RGB565
  * - 32: ARGB8888
  */
-#if defined CONFIG_LV_TFT_DISPLAY_MONOCHROME
-/* For the monochrome display driver controller, e.g. SSD1306 and SH1107, use a color depth of 1. */
-#define LV_COLOR_DEPTH     1
-#else
-#define LV_COLOR_DEPTH     16
-#endif
+#define LV_COLOR_DEPTH     CONFIG_LV_COLOR_DEPTH
 
 /* Swap the 2 bytes of RGB565 color.
  * Useful if the display has a 8 bit interface (e.g. SPI)*/

--- a/components/lvgl/lv_conf.h
+++ b/components/lvgl/lv_conf.h
@@ -45,7 +45,7 @@
  * - 16: RGB565
  * - 32: ARGB8888
  */
-#ifdef (CONFIG_LV_COLOR_DEPTH_1)
+#if defined (CONFIG_LV_COLOR_DEPTH_1)
 #define LV_COLOR_DEPTH     1
 #elif defined (CONFIG_LV_COLOR_DEPTH_8)
 #define LV_COLOR_DEPTH     8
@@ -57,7 +57,7 @@
 
 /* Swap the 2 bytes of RGB565 color.
  * Useful if the display has a 8 bit interface (e.g. SPI)*/
-#ifdef (CONFIG_LV_COLOR_16_SWAP)
+#if defined (CONFIG_LV_COLOR_16_SWAP)
 #define LV_COLOR_16_SWAP    1
 #else
 #define LV_COLOR_16_SWAP    0

--- a/components/lvgl/lv_conf.h
+++ b/components/lvgl/lv_conf.h
@@ -45,7 +45,15 @@
  * - 16: RGB565
  * - 32: ARGB8888
  */
-#define LV_COLOR_DEPTH     CONFIG_LV_COLOR_DEPTH
+#ifdef (CONFIG_LV_COLOR_DEPTH_1)
+#define LV_COLOR_DEPTH     1
+#elif defined (CONFIG_LV_COLOR_DEPTH_8)
+#define LV_COLOR_DEPTH     8
+#elif defined (CONFIG_LV_COLOR_DEPTH_16)
+#define LV_COLOR_DEPTH     16
+#elif defined (CONFIG_LV_COLOR_DEPTH_32)
+#define LV_COLOR_DEPTH     32
+#endif
 
 /* Swap the 2 bytes of RGB565 color.
  * Useful if the display has a 8 bit interface (e.g. SPI)*/

--- a/components/lvgl_esp32_drivers/lvgl_tft/Kconfig
+++ b/components/lvgl_esp32_drivers/lvgl_tft/Kconfig
@@ -309,6 +309,23 @@ menu "LVGL TFT Display controller"
         default n if LV_TFT_DISPLAY_CONTROLLER_FT81X
         default y if LV_TFT_DISPLAY_CONTROLLER_RA8875
         default y if LV_TFT_DISPLAY_CONTROLLER_GC9A01
+    
+    # TODO: This configuration option will be moved into the LVGL
+    # Kconfig menuconfig, let's leave that for the near future.
+    config LV_COLOR_DEPTH
+        # Color depth:
+        # 1: 1 byte per pixel
+        # 8: RGB233
+        # 16: RGB565
+        # 32: ARGB8888
+        int
+
+        default 1 if LV_TFT_DISPLAY_USER_CONTROLLER_SH1107
+        default 1 if LV_TFT_DISPLAY_USER_CONTROLLER_SSD1306
+        default 1 if LV_TFT_DISPLAY_USER_CONTROLLER_IL3820
+        default 1 if LV_TFT_DISPLAY_USER_CONTROLLER_JD79653A
+        default 1 if LV_TFT_DISPLAY_USER_CONTROLLER_UC8151D
+        default 16
 
     # Select one of the available FT81x configurations.
     choice

--- a/components/lvgl_esp32_drivers/lvgl_tft/Kconfig
+++ b/components/lvgl_esp32_drivers/lvgl_tft/Kconfig
@@ -310,23 +310,6 @@ menu "LVGL TFT Display controller"
         default y if LV_TFT_DISPLAY_CONTROLLER_RA8875
         default y if LV_TFT_DISPLAY_CONTROLLER_GC9A01
     
-    # TODO: This configuration option will be moved into the LVGL
-    # Kconfig menuconfig, let's leave that for the near future.
-    config LV_COLOR_DEPTH
-        # Color depth:
-        # 1: 1 byte per pixel
-        # 8: RGB233
-        # 16: RGB565
-        # 32: ARGB8888
-        int
-
-        default 1 if LV_TFT_DISPLAY_USER_CONTROLLER_SH1107
-        default 1 if LV_TFT_DISPLAY_USER_CONTROLLER_SSD1306
-        default 1 if LV_TFT_DISPLAY_USER_CONTROLLER_IL3820
-        default 1 if LV_TFT_DISPLAY_USER_CONTROLLER_JD79653A
-        default 1 if LV_TFT_DISPLAY_USER_CONTROLLER_UC8151D
-        default 16
-
     # Select one of the available FT81x configurations.
     choice
         prompt "Select a FT81x configuration." if LV_TFT_DISPLAY_USER_CONTROLLER_FT81X

--- a/components/lvgl_esp32_drivers/lvgl_tft/Kconfig
+++ b/components/lvgl_esp32_drivers/lvgl_tft/Kconfig
@@ -294,6 +294,22 @@ menu "LVGL TFT Display controller"
             select LV_TFT_DISPLAY_PROTOCOL_SPI
     endchoice
 
+    # TODO: This configuration option will be moved into the LVGL
+    # Kconfig menuconfig, let's leave that for the near future.
+    config LV_COLOR_16_SWAP
+        bool
+        default y if LV_TFT_DISPLAY_CONTROLLER_ILI9341
+        default n if LV_TFT_DISPLAY_CONTROLLER_ILI9488
+        default y if LV_TFT_DISPLAY_CONTROLLER_ST7789
+        default y if LV_TFT_DISPLAY_CONTROLLER_ST7735S
+        default y if LV_TFT_DISPLAY_CONTROLLER_HX8357
+        default n if LV_TFT_DISPLAY_CONTROLLER_SH1107
+        default n if LV_TFT_DISPLAY_CONTROLLER_SSD1306
+        default y if LV_TFT_DISPLAY_CONTROLLER_ILI9486
+        default n if LV_TFT_DISPLAY_CONTROLLER_FT81X
+        default y if LV_TFT_DISPLAY_CONTROLLER_RA8875
+        default y if LV_TFT_DISPLAY_CONTROLLER_GC9A01
+
     # Select one of the available FT81x configurations.
     choice
         prompt "Select a FT81x configuration." if LV_TFT_DISPLAY_USER_CONTROLLER_FT81X

--- a/components/lvgl_esp32_drivers/lvgl_tft/Kconfig
+++ b/components/lvgl_esp32_drivers/lvgl_tft/Kconfig
@@ -294,22 +294,6 @@ menu "LVGL TFT Display controller"
             select LV_TFT_DISPLAY_PROTOCOL_SPI
     endchoice
 
-    # TODO: This configuration option will be moved into the LVGL
-    # Kconfig menuconfig, let's leave that for the near future.
-    config LV_COLOR_16_SWAP
-        bool
-        default y if LV_TFT_DISPLAY_CONTROLLER_ILI9341
-        default n if LV_TFT_DISPLAY_CONTROLLER_ILI9488
-        default y if LV_TFT_DISPLAY_CONTROLLER_ST7789
-        default y if LV_TFT_DISPLAY_CONTROLLER_ST7735S
-        default y if LV_TFT_DISPLAY_CONTROLLER_HX8357
-        default n if LV_TFT_DISPLAY_CONTROLLER_SH1107
-        default n if LV_TFT_DISPLAY_CONTROLLER_SSD1306
-        default y if LV_TFT_DISPLAY_CONTROLLER_ILI9486
-        default n if LV_TFT_DISPLAY_CONTROLLER_FT81X
-        default y if LV_TFT_DISPLAY_CONTROLLER_RA8875
-        default y if LV_TFT_DISPLAY_CONTROLLER_GC9A01
-    
     # Select one of the available FT81x configurations.
     choice
         prompt "Select a FT81x configuration." if LV_TFT_DISPLAY_USER_CONTROLLER_FT81X


### PR DESCRIPTION
This is to cleanup the `lv_conf` file from configuration depending on the chosen driver, the configuration is solved at `Kconfig` level.
All this work is towards using lvgl as a esp-idf component.