### PR TITLE
Remove 'Temporal workaround' section in README and fix related problem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 
-include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-list(APPEND EXTRA_COMPONENT_DIRS components/lvgl_esp32_drivers components/lvgl_esp32_drivers/lvgl_touch components/lvgl_esp32_drivers/lvgl_tft)
-
 if (NOT DEFINED PROJECT_NAME)
-	project(lvgl-demo)
+    include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+ 
+    list(APPEND EXTRA_COMPONENT_DIRS components/lvgl_esp32_drivers components/lvgl_esp32_drivers/lvgl_touch components/lvgl_esp32_drivers/lvgl_tft)
+
+    project(lvgl-demo)
 endif (NOT DEFINED PROJECT_NAME)

--- a/README.md
+++ b/README.md
@@ -134,27 +134,6 @@ set(EXTRA_COMPONENT_DIRS components/lv_port_esp32/components/lv_examples compone
 project(blink)
 ```
 
-
-### Temporal workaround
-
-When adding this project as a component you need to update it's CMakeLists.txt file located at the root directory, like so (comment out the include line):
-
-`components/lv_port_esp32/CMakeLists.txt`
-
-```cmake
-
-cmake_minimum_required(VERSION 3.5)
-
-# include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-
-set(EXTRA_COMPONENT_DIRS components/lv_port_esp32/components/lv_examples components/lv_port_esp32/components/lvgl components/lv_port_esp32/components/lvgl_esp32_drivers/lvgl_tft components/lv_port_esp32/components/lvgl_esp32_drivers/lvgl_touch components/lv_port_esp32/components/lvgl_esp32_drivers)
-
-if (NOT DEFINED PROJECT_NAME)
-	project(lvgl-demo)
-endif (NOT DEFINED PROJECT_NAME)
-
-```
-
 In the CMakeLists.txt file for your `/main` or for the component(s) using LVGL you need to add REQUIRES directives for this project's driver and lvgl itself to the `idf_component_register` function, it should look like this:
 
 


### PR DESCRIPTION
In this PR I have removed 'Temporal workaround' section in README and fixed related problem described in #85 issue (see [my comment](https://github.com/lvgl/lv_port_esp32/issues/85#issuecomment-701982298)).

Looks like everything is working as expected after these changes (I can reconfigure and build this and my projects without any compilation errors).

@C47D @Mair Could you please review this PR?