### PR TITLE
lvgl: Replace LV_FONT_MONTSERRAT12SUBPIX option with LV_FONT_MONTSERR…

### DIFF
--- a/components/lvgl/Kconfig
+++ b/components/lvgl/Kconfig
@@ -143,7 +143,7 @@ menu "LVGL configuration"
             config LV_FONT_UNSCII8
                     bool
                     prompt "Enable UNSCII 8 (Perfect monospace font)"
-            config LV_FONT_MONTSERRAT12SUBPIX
+            config LV_FONT_MONTSERRAT12SUBPX
                     bool
                     prompt "Enable Montserrat 12 sub-pixel"
             config LV_FONT_MONTSERRAT28COMPRESSED
@@ -223,9 +223,9 @@ menu "LVGL configuration"
             config LV_FONT_DEFAULT_SMALL_UNSCII8
                 bool "UNSCII 8 (Perfect monospace font)"
                 select LV_FONT_UNSCII8
-            config LV_FONT_DEFAULT_SMALL_MONTSERRAT12SUBPIX
+            config LV_FONT_DEFAULT_SMALL_MONTSERRAT12SUBPX
                 bool "Montserrat 12 sub-pixel"
-                select LV_FONT_MONTSERRAT12SUBPIX
+                select LV_FONT_MONTSERRAT12SUBPX
             config LV_FONT_DEFAULT_SMALL_MONTSERRAT28COMPRESSED
                 bool "Montserrat 28 compressed"
                 select LV_FONT_MONTSERRAT28COMPRESSED
@@ -303,9 +303,9 @@ menu "LVGL configuration"
             config LV_FONT_DEFAULT_NORMAL_UNSCII8
                 bool "UNSCII 8 (Perfect monospace font)"
                 select LV_FONT_UNSCII8
-            config LV_FONT_DEFAULT_NORMAL_MONTSERRAT12SUBPIX
+            config LV_FONT_DEFAULT_NORMAL_MONTSERRAT12SUBPX
                 bool "Montserrat 12 sub-pixel"
-                select LV_FONT_MONTSERRAT12SUBPIX
+                select LV_FONT_MONTSERRAT12SUBPX
             config LV_FONT_DEFAULT_NORMAL_MONTSERRAT28COMPRESSED
                 bool "Montserrat 28 compressed"
                 select LV_FONT_MONTSERRAT28COMPRESSED
@@ -383,9 +383,9 @@ menu "LVGL configuration"
             config LV_FONT_DEFAULT_SUBTITLE_UNSCII8
                 bool "UNSCII 8 (Perfect monospace font)"
                 select LV_FONT_UNSCII8
-            config LV_FONT_DEFAULT_SUBTITLE_MONTSERRAT12SUBPIX
+            config LV_FONT_DEFAULT_SUBTITLE_MONTSERRAT12SUBPX
                 bool "Montserrat 12 sub-pixel"
-                select LV_FONT_MONTSERRAT12SUBPIX
+                select LV_FONT_MONTSERRAT12SUBPX
             config LV_FONT_DEFAULT_SUBTITLE_MONTSERRAT28COMPRESSED
                 bool "Montserrat 28 compressed"
                 select LV_FONT_MONTSERRAT28COMPRESSED
@@ -463,9 +463,9 @@ menu "LVGL configuration"
             config LV_FONT_DEFAULT_TITLE_UNSCII8
                 bool "UNSCII 8 (Perfect monospace font)"
                 select LV_FONT_UNSCII8
-            config LV_FONT_DEFAULT_TITLE_MONTSERRAT12SUBPIX
+            config LV_FONT_DEFAULT_TITLE_MONTSERRAT12SUBPX
                 bool "Montserrat 12 sub-pixel"
-                select LV_FONT_MONTSERRAT12SUBPIX
+                select LV_FONT_MONTSERRAT12SUBPX
             config LV_FONT_DEFAULT_TITLE_MONTSERRAT28COMPRESSED
                 bool "Montserrat 28 compressed"
                 select LV_FONT_MONTSERRAT28COMPRESSED

--- a/components/lvgl/lv_conf.h
+++ b/components/lvgl/lv_conf.h
@@ -727,7 +727,7 @@ typedef void * lv_font_user_data_t;
 #define LV_THEME_DEFAULT_FONT_SMALL         &lv_font_montserrat_48
 #elif defined CONFIG_LV_FONT_DEFAULT_SMALL_UNSCII8
 #define LV_THEME_DEFAULT_FONT_SMALL         &lv_font_unscii_8
-#elif defined CONFIG_LV_FONT_DEFAULT_SMALL_MONTSERRAT12SUBPIX
+#elif defined CONFIG_LV_FONT_DEFAULT_SMALL_MONTSERRAT12SUBPX
 #define LV_THEME_DEFAULT_FONT_SMALL         &lv_font_montserrat_12_subpx
 #elif defined CONFIG_LV_FONT_DEFAULT_SMALL_MONTSERRAT28COMPRESSED
 #define LV_THEME_DEFAULT_FONT_SMALL         &lv_font_montserrat_28_compressed
@@ -779,7 +779,7 @@ typedef void * lv_font_user_data_t;
 #define LV_THEME_DEFAULT_FONT_NORMAL         &lv_font_montserrat_48
 #elif defined CONFIG_LV_FONT_DEFAULT_NORMAL_UNSCII8
 #define LV_THEME_DEFAULT_FONT_NORMAL         &lv_font_unscii_8
-#elif defined CONFIG_LV_FONT_DEFAULT_NORMAL_MONTSERRAT12SUBPIX
+#elif defined CONFIG_LV_FONT_DEFAULT_NORMAL_MONTSERRAT12SUBPX
 #define LV_THEME_DEFAULT_FONT_NORMAL         &lv_font_montserrat_12_subpx
 #elif defined CONFIG_LV_FONT_DEFAULT_NORMAL_MONTSERRAT28COMPRESSED
 #define LV_THEME_DEFAULT_FONT_NORMAL         &lv_font_montserrat_28_compressed
@@ -831,7 +831,7 @@ typedef void * lv_font_user_data_t;
 #define LV_THEME_DEFAULT_FONT_SUBTITLE         &lv_font_montserrat_48
 #elif defined CONFIG_LV_FONT_DEFAULT_SUBTITLE_UNSCII8
 #define LV_THEME_DEFAULT_FONT_SUBTITLE         &lv_font_unscii_8
-#elif defined CONFIG_LV_FONT_DEFAULT_SUBTITLE_MONTSERRAT12SUBPIX
+#elif defined CONFIG_LV_FONT_DEFAULT_SUBTITLE_MONTSERRAT12SUBPX
 #define LV_THEME_DEFAULT_FONT_SUBTITLE         &lv_font_montserrat_12_subpx
 #elif defined CONFIG_LV_FONT_DEFAULT_SUBTITLE_MONTSERRAT28COMPRESSED
 #define LV_THEME_DEFAULT_FONT_SUBTITLE         &lv_font_montserrat_28_compressed
@@ -883,7 +883,7 @@ typedef void * lv_font_user_data_t;
 #define LV_THEME_DEFAULT_FONT_TITLE         &lv_font_montserrat_48
 #elif defined CONFIG_LV_FONT_DEFAULT_TITLE_UNSCII8
 #define LV_THEME_DEFAULT_FONT_TITLE         &lv_font_unscii_8
-#elif defined CONFIG_LV_FONT_DEFAULT_TITLE_MONTSERRAT12SUBPIX
+#elif defined CONFIG_LV_FONT_DEFAULT_TITLE_MONTSERRAT12SUBPX
 #define LV_THEME_DEFAULT_FONT_TITLE         &lv_font_montserrat_12_subpx
 #elif defined CONFIG_LV_FONT_DEFAULT_TITLE_MONTSERRAT28COMPRESSED
 #define LV_THEME_DEFAULT_FONT_TITLE         &lv_font_montserrat_28_compressed


### PR DESCRIPTION
…AT12SUBPX

Use LV_FONT_MONTSERRAT12SUBPX where needed to keep consistency.