### PR TITLE
Including "lvgl.h" if LV_LVGL_H_INCLUDE_SIMPLE is defined.

### DIFF
--- a/components/lvgl_esp32_drivers/lvgl_i2c_conf.h
+++ b/components/lvgl_esp32_drivers/lvgl_i2c_conf.h
@@ -12,7 +12,11 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include "lvgl.h"
+#else
 #include "lvgl/lvgl.h"
+#endif
 
 /*********************
  *      DEFINES

--- a/components/lvgl_esp32_drivers/lvgl_tft/EVE_config.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/EVE_config.h
@@ -35,7 +35,11 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 #ifndef EVE_CONFIG_H_
 #define EVE_CONFIG_H_
 
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include "lvgl.h"
+#else
 #include "lvgl/lvgl.h"
+#endif
 #include "../lvgl_spi_conf.h"
 
 #include "FT81x.h"

--- a/components/lvgl_esp32_drivers/lvgl_tft/FT81x.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/FT81x.h
@@ -3,7 +3,11 @@
 
 #include <stdint.h>
 
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include "lvgl.h"
+#else
 #include "lvgl/lvgl.h"
+#endif
 #include "../lvgl_helpers.h"
 
 void FT81x_init(void);

--- a/components/lvgl_esp32_drivers/lvgl_tft/GC9A01.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/GC9A01.h
@@ -15,7 +15,11 @@ extern "C" {
  *********************/
 #include <stdbool.h>
 
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include "lvgl.h"
+#else
 #include "lvgl/lvgl.h"
+#endif
 #include "../lvgl_helpers.h"
 
 /*********************

--- a/components/lvgl_esp32_drivers/lvgl_tft/disp_driver.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/disp_driver.h
@@ -12,7 +12,11 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include "lvgl.h"
+#else
 #include "lvgl/lvgl.h"
+#endif
 
 #if defined CONFIG_LV_TFT_DISPLAY_CONTROLLER_ILI9341
 #include "ili9341.h"

--- a/components/lvgl_esp32_drivers/lvgl_tft/disp_spi.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/disp_spi.c
@@ -19,7 +19,11 @@
 #include <freertos/semphr.h>
 #include <freertos/task.h>
 
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include "lvgl.h"
+#else
 #include "lvgl/lvgl.h"
+#endif
 
 #include "disp_spi.h"
 #include "disp_driver.h"

--- a/components/lvgl_esp32_drivers/lvgl_tft/hx8357.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/hx8357.h
@@ -25,7 +25,11 @@ extern "C" {
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include "lvgl.h"
+#else
 #include "lvgl/lvgl.h"
+#endif
 #include "../lvgl_helpers.h"
 
  /*********************

--- a/components/lvgl_esp32_drivers/lvgl_tft/il3820.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/il3820.h
@@ -11,7 +11,11 @@ extern "C"
 {
 #endif
 
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include "lvgl.h"
+#else
 #include "lvgl/lvgl.h"
+#endif
 #include "sdkconfig.h"
 
 /* Values for Waveshare 2.9inch e-Paper Module, this values shouldn't be

--- a/components/lvgl_esp32_drivers/lvgl_tft/ili9341.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/ili9341.h
@@ -15,7 +15,11 @@ extern "C" {
  *********************/
 #include <stdbool.h>
 
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include "lvgl.h"
+#else
 #include "lvgl/lvgl.h"
+#endif
 #include "../lvgl_helpers.h"
 
 /*********************

--- a/components/lvgl_esp32_drivers/lvgl_tft/ili9481.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/ili9481.h
@@ -15,7 +15,11 @@ extern "C" {
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include "lvgl.h"
+#else
 #include "lvgl/lvgl.h"
+#endif
 #include "../lvgl_helpers.h"
 
 /*********************

--- a/components/lvgl_esp32_drivers/lvgl_tft/ili9486.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/ili9486.h
@@ -15,7 +15,11 @@ extern "C" {
  *********************/
 #include <stdbool.h>
 
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include "lvgl.h"
+#else
 #include "lvgl/lvgl.h"
+#endif
 #include "../lvgl_helpers.h"
 
 /*********************

--- a/components/lvgl_esp32_drivers/lvgl_tft/ili9488.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/ili9488.h
@@ -15,7 +15,11 @@ extern "C" {
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include "lvgl.h"
+#else
 #include "lvgl/lvgl.h"
+#endif
 #include "../lvgl_helpers.h"
 
 /*********************

--- a/components/lvgl_esp32_drivers/lvgl_tft/jd79653a.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/jd79653a.h
@@ -11,7 +11,11 @@ extern "C"
 {
 #endif
 
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include "lvgl.h"
+#else
 #include "lvgl/lvgl.h"
+#endif
 
 void jd79653a_init();
 void jd79653a_deep_sleep();

--- a/components/lvgl_esp32_drivers/lvgl_tft/ra8875.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/ra8875.h
@@ -15,7 +15,11 @@ extern "C" {
  *********************/
 #include <stdbool.h>
 
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include "lvgl.h"
+#else
 #include "lvgl/lvgl.h"
+#endif
 
 /*********************
  *      DEFINES

--- a/components/lvgl_esp32_drivers/lvgl_tft/sh1107.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/sh1107.h
@@ -15,7 +15,11 @@ extern "C" {
  *********************/
 #include <stdbool.h>
 
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include "lvgl.h"
+#else
 #include "lvgl/lvgl.h"
+#endif
 #include "../lvgl_helpers.h"
 
 /*********************

--- a/components/lvgl_esp32_drivers/lvgl_tft/ssd1306.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/ssd1306.h
@@ -15,7 +15,11 @@ extern "C" {
  *********************/
 #include <stdbool.h>
 
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include "lvgl.h"
+#else
 #include "lvgl/lvgl.h"
+#endif
 #include "../lvgl_helpers.h"
 
 /*********************

--- a/components/lvgl_esp32_drivers/lvgl_tft/st7735s.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/st7735s.h
@@ -14,7 +14,11 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include <stdbool.h>
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include "lvgl.h"
+#else
 #include "lvgl/lvgl.h"
+#endif
 
 /*********************
  *      DEFINES

--- a/components/lvgl_esp32_drivers/lvgl_tft/st7789.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/st7789.h
@@ -12,7 +12,11 @@ extern "C"
 {
 #endif
 
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include "lvgl.h"
+#else
 #include "lvgl/lvgl.h"
+#endif
 #include "../lvgl_helpers.h"
 
 #include "sdkconfig.h"

--- a/components/lvgl_esp32_drivers/lvgl_touch/FT81x.h
+++ b/components/lvgl_esp32_drivers/lvgl_touch/FT81x.h
@@ -15,7 +15,11 @@ extern "C" {
 
 #include <stdint.h>
 #include <stdbool.h>
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include "lvgl.h"
+#else
 #include "lvgl/lvgl.h"
+#endif
 
 /*********************
  *      DEFINES

--- a/components/lvgl_esp32_drivers/lvgl_touch/adcraw.h
+++ b/components/lvgl_esp32_drivers/lvgl_touch/adcraw.h
@@ -13,7 +13,11 @@ extern "C" {
 #include <stdbool.h>
 #include "driver/gpio.h"
 #include "driver/adc.h"
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include "lvgl.h"
+#else
 #include "lvgl/lvgl.h"
+#endif
 
 #define TOUCHSCREEN_RESISTIVE_PIN_YU CONFIG_LV_TOUCHSCREEN_RESSITIVE_PIN_YU // Y+ any gpio
 #define TOUCHSCREEN_RESISTIVE_PIN_YD CONFIG_LV_TOUCHSCREEN_RESISTIVE_PIN_YD // Y- also ADC

--- a/components/lvgl_esp32_drivers/lvgl_touch/ra8875_touch.h
+++ b/components/lvgl_esp32_drivers/lvgl_touch/ra8875_touch.h
@@ -15,7 +15,11 @@ extern "C" {
 
 #include <stdint.h>
 #include <stdbool.h>
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include "lvgl.h"
+#else
 #include "lvgl/lvgl.h"
+#endif
 
 /*********************
  *      DEFINES

--- a/components/lvgl_esp32_drivers/lvgl_touch/stmpe610.h
+++ b/components/lvgl_esp32_drivers/lvgl_touch/stmpe610.h
@@ -15,7 +15,11 @@ extern "C" {
 
 #include <stdint.h>
 #include <stdbool.h>
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include "lvgl.h"
+#else
 #include "lvgl/lvgl.h"
+#endif
 
 /*********************
  *      DEFINES

--- a/components/lvgl_esp32_drivers/lvgl_touch/touch_driver.h
+++ b/components/lvgl_esp32_drivers/lvgl_touch/touch_driver.h
@@ -14,7 +14,11 @@ extern "C" {
  *********************/
 #include <stdint.h>
 #include <stdbool.h>
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include "lvgl.h"
+#else
 #include "lvgl/lvgl.h"
+#endif
 
 #if defined (CONFIG_LV_TOUCH_CONTROLLER_XPT2046)
 #include "xpt2046.h"

--- a/components/lvgl_esp32_drivers/lvgl_touch/xpt2046.h
+++ b/components/lvgl_esp32_drivers/lvgl_touch/xpt2046.h
@@ -16,7 +16,11 @@ extern "C" {
 
 #include <stdint.h>
 #include <stdbool.h>
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include "lvgl.h"
+#else
 #include "lvgl/lvgl.h"
+#endif
 
 /*********************
  *      DEFINES


### PR DESCRIPTION
When LV_LVGL_H_INCLUDE_SIMPLE is not defined (the default) then
`"lvgl/lvgl.h"` is included, else `"lvgl.h"` is included.
This is for other build systems (like PlatformiIO) which setup
build paths differently than esp-idf. More info in issue #220.

This approach is identical to that used by https://github.com/lvgl/lv_drivers.