### PR TITLE
Including lv_core/lv_refr.h differently form platformio.

### DIFF
--- a/components/lvgl_esp32_drivers/lvgl_helpers.c
+++ b/components/lvgl_esp32_drivers/lvgl_helpers.c
@@ -18,7 +18,11 @@
 
 #include "driver/i2c.h"
 
+#if defined(PLATFORMIO)
+#include "lv_core/lv_refr.h"
+#else
 #include "lvgl/src/lv_core/lv_refr.h"
+#endif
 
 /*********************
  *      DEFINES


### PR DESCRIPTION
PlatformIO compiles using a different include path strategy than
esp-idf. If PLATFORMIO is defined then `"lv_core/lv_refr.h"` will
be included, otherwise `"lvgl/src/lv_core/lv_refr.h"`. More info
in issue #220.