### PR TITLE
Including lvgl.h differently based on LV_LVGL_H_INCLUDE_SIMPLE.

### DIFF
--- a/components/lvgl_esp32_drivers/lvgl_touch/ft6x36.c
+++ b/components/lvgl_esp32_drivers/lvgl_touch/ft6x36.c
@@ -20,7 +20,11 @@
 
 #include <esp_log.h>
 #include <driver/i2c.h>
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include <lvgl.h>
+#else
 #include <lvgl/lvgl.h>
+#endif
 #include "ft6x36.h"
 #include "tp_i2c.h"
 


### PR DESCRIPTION
This was missed and should have been part of 31c6ed0154600dd9ebe78f3538ed479be8b12aea.