### PR TITLE
ifdef'ing out contents of driver source/header files when not used.

### DIFF
--- a/components/lvgl_esp32_drivers/lvgl_tft/EVE_commands.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/EVE_commands.c
@@ -61,6 +61,8 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 #include <stdarg.h>
 #endif
 
+#if defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_FT81X) || defined(CONFIG_LV_TFT_TOUCH_CONTROLLER_FT81X)
+
 #define TAG "FT81X"
 
 /* data structure for SPI reading that has (optional) space for inserted dummy byte */
@@ -2311,3 +2313,5 @@ void EVE_calibrate_manual(uint16_t height)
 	EVE_memWrite32(REG_TOUCH_TRANSFORM_F, TransMatrix[5]);
 }
 #endif // FT81X_FULL
+
+#endif  // defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_FT81X) || defined(CONFIG_LV_TFT_TOUCH_CONTROLLER_FT81X)

--- a/components/lvgl_esp32_drivers/lvgl_tft/EVE_commands.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/EVE_commands.h
@@ -31,6 +31,10 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 	  It has also been trimmed down to suit LvGL's needs. Extra features can be enabled by defining FT81X_FULL
 */
 
+#include <sdkconfig.h>
+
+#if defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_FT81X) || defined(CONFIG_LV_TFT_TOUCH_CONTROLLER_FT81X)
+
 #include "EVE.h"
 
 #ifndef EVE_COMMANDS_H_
@@ -199,5 +203,7 @@ void EVE_calibrate_manual(uint16_t height);
 
 /* startup FT8xx: */
 uint8_t EVE_init(void);
+
+#endif // defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_FT81X) || defined(CONFIG_LV_TFT_TOUCH_CONTROLLER_FT81X)
 
 #endif /* EVE_COMMANDS_H_ */

--- a/components/lvgl_esp32_drivers/lvgl_tft/FT81x.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/FT81x.c
@@ -2,11 +2,14 @@
 #include <stdio.h>
 
 #include "driver/gpio.h"
+#include <sdkconfig.h>
 
 #include "FT81x.h"
 
 #include "EVE.h"
 #include "EVE_commands.h"
+
+#if defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_FT81X)
 
 /* some pre-definded colors */
 #define RED		0xff0000UL
@@ -321,3 +324,5 @@ void FT81x_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color
 {
 	TFT_WriteBitmap((uint8_t*)color_map, area->x1, area->y1, lv_area_get_width(area), lv_area_get_height(area));
 }
+
+#endif  // defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_FT81X)

--- a/components/lvgl_esp32_drivers/lvgl_tft/FT81x.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/FT81x.h
@@ -10,8 +10,12 @@
 #endif
 #include "../lvgl_helpers.h"
 
+#if defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_FT81X)
+
 void FT81x_init(void);
 
 void FT81x_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color_map);
+
+#endif  // defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_FT81X)
 
 #endif /* FT81X_H_ */

--- a/components/lvgl_esp32_drivers/lvgl_tft/GC9A01.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/GC9A01.c
@@ -13,6 +13,8 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
+#if defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_GC9A01)
+
 /*********************
  *      DEFINES
  *********************/
@@ -270,3 +272,5 @@ static void GC9A01_set_orientation(uint8_t orientation)
     GC9A01_send_cmd(0x36);
     GC9A01_send_data((void *) &data[orientation], 1);
 }
+
+#endif  // defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_GC9A01)

--- a/components/lvgl_esp32_drivers/lvgl_tft/GC9A01.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/GC9A01.h
@@ -22,6 +22,8 @@ extern "C" {
 #endif
 #include "../lvgl_helpers.h"
 
+#if defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_GC9A01)
+
 /*********************
  *      DEFINES
  *********************/
@@ -57,6 +59,7 @@ void GC9A01_sleep_out(void);
  *      MACROS
  **********************/
 
+#endif  // defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_GC9A01)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/components/lvgl_esp32_drivers/lvgl_tft/ili9341.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/ili9341.c
@@ -13,6 +13,8 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
+#if defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_ILI9341)
+
 /*********************
  *      DEFINES
  *********************/
@@ -239,3 +241,5 @@ static void ili9341_set_orientation(uint8_t orientation)
     ili9341_send_cmd(0x36);
     ili9341_send_data((void *) &data[orientation], 1);
 }
+
+#endif  // defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_ILI9341)

--- a/components/lvgl_esp32_drivers/lvgl_tft/ili9341.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/ili9341.h
@@ -22,6 +22,8 @@ extern "C" {
 #endif
 #include "../lvgl_helpers.h"
 
+#if defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_ILI9341)
+
 /*********************
  *      DEFINES
  *********************/
@@ -57,6 +59,7 @@ void ili9341_sleep_out(void);
  *      MACROS
  **********************/
 
+#endif  // defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_ILI9341)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/components/lvgl_esp32_drivers/lvgl_tft/ili9481.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/ili9481.c
@@ -14,6 +14,8 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
+#if defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_ILI9481)
+
 /*********************
  *      DEFINES
  *********************/
@@ -222,3 +224,5 @@ static void ili9481_set_orientation(uint8_t orientation)
     ili9481_send_cmd(ILI9481_CMD_MEMORY_ACCESS_CONTROL);
     ili9481_send_data((void *) &data[orientation], 1);
 }
+
+#endif  // defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_ILI9481)

--- a/components/lvgl_esp32_drivers/lvgl_tft/ili9481.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/ili9481.h
@@ -22,6 +22,8 @@ extern "C" {
 #endif
 #include "../lvgl_helpers.h"
 
+#if defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_ILI9481)
+
 /*********************
  *      DEFINES
  *********************/
@@ -122,6 +124,8 @@ void ili9481_enable_backlight(bool backlight);
 /**********************
  *      MACROS
  **********************/
+
+#endif  // defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_ILI9481)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/components/lvgl_esp32_drivers/lvgl_tft/jd79653a.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/jd79653a.c
@@ -34,6 +34,8 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 #include "disp_spi.h"
 #include "jd79653a.h"
 
+#if defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_JD79653A)
+
 #define TAG "lv_jd79653a"
 
 #define PIN_DC              CONFIG_LV_DISP_PIN_DC
@@ -480,3 +482,5 @@ void jd79653a_init()
 
     ESP_LOGI(TAG, "Panel is up!");
 }
+
+#endif  // defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_JD79653A)

--- a/components/lvgl_esp32_drivers/lvgl_tft/jd79653a.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/jd79653a.h
@@ -17,6 +17,8 @@ extern "C"
 #include "lvgl/lvgl.h"
 #endif
 
+#if defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_JD79653A)
+
 void jd79653a_init();
 void jd79653a_deep_sleep();
 
@@ -28,6 +30,7 @@ void jd79653a_lv_fb_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t 
 void jd79653a_fb_set_full_color(uint8_t color);
 void jd79653a_fb_full_update(uint8_t *data, size_t len);
 
+#endif  // defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_JD79653A)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/components/lvgl_esp32_drivers/lvgl_tft/ra8875.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/ra8875.c
@@ -13,6 +13,8 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
+#if defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_RA8875)
+
 /*********************
  *      DEFINES
  *********************/
@@ -363,3 +365,5 @@ static void ra8875_send_buffer(uint8_t * data, size_t length, bool signal_flush)
                           | (RA8875_MODE_DATA_WRITE);          // Data write mode
     disp_spi_transaction(data, length, flags, NULL, prefix, 0);
 }
+
+#endif  // defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_RA8875)

--- a/components/lvgl_esp32_drivers/lvgl_tft/ra8875.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/ra8875.h
@@ -21,6 +21,8 @@ extern "C" {
 #include "lvgl/lvgl.h"
 #endif
 
+#if defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_RA8875)
+
 /*********************
  *      DEFINES
  *********************/
@@ -110,6 +112,7 @@ void ra8875_write_cmd(uint8_t cmd, uint8_t data);
  *      MACROS
  **********************/
 
+#endif  // defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_RA8875)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/components/lvgl_esp32_drivers/lvgl_tft/ssd1306.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/ssd1306.c
@@ -14,6 +14,8 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
+#if defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_SSD1306)
+
 /*********************
  *      DEFINES
  *********************/
@@ -238,3 +240,4 @@ void ssd1306_sleep_out()
  *   STATIC FUNCTIONS
  **********************/
 
+#endif  // defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_SSD1306)

--- a/components/lvgl_esp32_drivers/lvgl_tft/ssd1306.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/ssd1306.h
@@ -22,6 +22,8 @@ extern "C" {
 #endif
 #include "../lvgl_helpers.h"
 
+#if defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_SSD1306)
+
 /*********************
  *      DEFINES
  *********************/
@@ -49,6 +51,7 @@ void ssd1306_sleep_out(void);
  *      MACROS
  **********************/
 
+#endif  // defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_SSD1306)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/components/lvgl_esp32_drivers/lvgl_tft/st7735s.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/st7735s.c
@@ -14,6 +14,8 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
+#if defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_ST7735S)
+
 /*********************
  *      DEFINES
  *********************/
@@ -267,3 +269,5 @@ static void axp192_sleep_out()
 {
 	axp192_write_byte(0x12, 0x4d);
 }
+
+#endif  // defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_ST7735S)

--- a/components/lvgl_esp32_drivers/lvgl_tft/st7735s.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/st7735s.h
@@ -20,6 +20,8 @@ extern "C" {
 #include "lvgl/lvgl.h"
 #endif
 
+#if defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_ST7735S)
+
 /*********************
  *      DEFINES
  *********************/
@@ -141,6 +143,8 @@ void st7735s_sleep_out(void);
 /**********************
  *      MACROS
  **********************/
+
+#endif  // defined(CONFIG_LV_TFT_DISPLAY_CONTROLLER_ST7735S)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/components/lvgl_esp32_drivers/lvgl_tft/uc8151d.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/uc8151d.c
@@ -35,6 +35,8 @@
 #include "disp_driver.h"
 #include "uc8151d.h"
 
+#if defined(CONFIG_LV_TOUCH_CONTROLLER_UC8151D)
+
 #define TAG "lv_uc8151d"
 
 #define PIN_DC              CONFIG_LV_DISP_PIN_DC
@@ -266,3 +268,5 @@ void uc8151d_init()
     uc8151d_panel_init();
     ESP_LOGI(TAG, "Panel initialised");
 }
+
+#endif  // defined(CONFIG_LV_TOUCH_CONTROLLER_UC8151D)

--- a/components/lvgl_esp32_drivers/lvgl_tft/uc8151d.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/uc8151d.h
@@ -29,11 +29,15 @@
 
 #include <lvgl.h>
 
+#if defined(CONFIG_LV_TOUCH_CONTROLLER_UC8151D)
+
 void uc8151d_init();
 void uc8151d_lv_set_fb_cb(struct _disp_drv_t *disp_drv, uint8_t *buf, lv_coord_t buf_w, lv_coord_t x, lv_coord_t y,
                           lv_color_t color, lv_opa_t opa);
 
 void uc8151d_lv_rounder_cb(struct _disp_drv_t *disp_drv, lv_area_t *area);
 void uc8151d_lv_fb_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_map);
+
+#endif  // defined(CONFIG_LV_TOUCH_CONTROLLER_UC8151D)
 
 #endif //LVGL_DEMO_UC8151D_H

--- a/components/lvgl_esp32_drivers/lvgl_touch/FT81x.c
+++ b/components/lvgl_esp32_drivers/lvgl_touch/FT81x.c
@@ -18,6 +18,8 @@
 #include "../lvgl_tft/EVE.h"
 #include "../lvgl_tft/EVE_commands.h"
 
+#if defined(CONFIG_LV_TOUCH_CONTROLLER_FT81X)
+
 
 /*********************
  *      DEFINES
@@ -83,3 +85,5 @@ bool FT81x_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
 /**********************
  *   STATIC FUNCTIONS
  **********************/
+
+#endif  // defined(CONFIG_LV_TOUCH_CONTROLLER_FT81X)

--- a/components/lvgl_esp32_drivers/lvgl_touch/FT81x.h
+++ b/components/lvgl_esp32_drivers/lvgl_touch/FT81x.h
@@ -21,6 +21,8 @@ extern "C" {
 #include "lvgl/lvgl.h"
 #endif
 
+#if defined(CONFIG_LV_TOUCH_CONTROLLER_FT81X)
+
 /*********************
  *      DEFINES
  *********************/
@@ -38,6 +40,8 @@ bool FT81x_read(lv_indev_drv_t * drv, lv_indev_data_t * data);
 /**********************
  *      MACROS
  **********************/
+
+#endif  // defined(CONFIG_LV_TOUCH_CONTROLLER_FT81X)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/components/lvgl_esp32_drivers/lvgl_touch/ft6x36.c
+++ b/components/lvgl_esp32_drivers/lvgl_touch/ft6x36.c
@@ -28,6 +28,8 @@
 #include "ft6x36.h"
 #include "tp_i2c.h"
 
+#if defined(CONFIG_LV_TOUCH_CONTROLLER_FT6X06)
+
 #define TAG "FT6X36"
 
 
@@ -198,3 +200,5 @@ bool ft6x36_read(lv_indev_drv_t *drv, lv_indev_data_t *data) {
     ESP_LOGV(TAG, "X=%u Y=%u", data->point.x, data->point.y);
     return false;
 }
+
+#endif  // defined(CONFIG_LV_TOUCH_CONTROLLER_FT6X06)

--- a/components/lvgl_esp32_drivers/lvgl_touch/ft6x36.h
+++ b/components/lvgl_esp32_drivers/lvgl_touch/ft6x36.h
@@ -21,6 +21,10 @@
 
 #define __FT6X06_H
 
+#include <sdkconfig.h>
+
+#if defined(CONFIG_LV_TOUCH_CONTROLLER_FT6X06)
+
 #include <lvgl/src/lv_hal/lv_hal.h>
 
 #ifdef __cplusplus
@@ -159,4 +163,7 @@ bool ft6x36_read(lv_indev_drv_t *drv, lv_indev_data_t *data);
 #ifdef __cplusplus
 }
 #endif
+
+#endif  // defined(CONFIG_LV_TOUCH_CONTROLLER_FT6X06)
+
 #endif /* __FT6X06_H */

--- a/components/lvgl_esp32_drivers/lvgl_touch/ra8875_touch.c
+++ b/components/lvgl_esp32_drivers/lvgl_touch/ra8875_touch.c
@@ -15,6 +15,8 @@
 
 #include "../lvgl_tft/ra8875.h"
 
+#if defined(CONFIG_LV_TOUCH_CONTROLLER_RA8875)
+
 #ifndef CONFIG_LV_TFT_DISPLAY_CONTROLLER_RA8875
     #error "Display controller must be RA8875"
 #endif
@@ -179,3 +181,5 @@ static void ra8875_corr(int * x, int * y)
     (*y) = (LV_VER_RES-1) - (*y);
 #endif
 }
+
+#endif  // defined(CONFIG_LV_TOUCH_CONTROLLER_RA8875)

--- a/components/lvgl_esp32_drivers/lvgl_touch/ra8875_touch.h
+++ b/components/lvgl_esp32_drivers/lvgl_touch/ra8875_touch.h
@@ -21,6 +21,8 @@ extern "C" {
 #include "lvgl/lvgl.h"
 #endif
 
+#if defined(CONFIG_LV_TOUCH_CONTROLLER_RA8875)
+
 /*********************
  *      DEFINES
  *********************/
@@ -48,6 +50,8 @@ bool ra8875_touch_read(lv_indev_drv_t * drv, lv_indev_data_t * data);
 /**********************
  *      MACROS
  **********************/
+
+#endif  // defined(CONFIG_LV_TOUCH_CONTROLLER_RA8875)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/components/lvgl_esp32_drivers/lvgl_touch/stmpe610.c
+++ b/components/lvgl_esp32_drivers/lvgl_touch/stmpe610.c
@@ -14,6 +14,8 @@
 #include "tp_spi.h"
 #include <stddef.h>
 
+#if defined(CONFIG_LV_TOUCH_CONTROLLER_STMPE610)
+
 /*********************
  *      DEFINES
  *********************/
@@ -240,3 +242,4 @@ static void adjust_data(int16_t * x, int16_t * y)
 
 }
 
+#endif  // defined(CONFIG_LV_TOUCH_CONTROLLER_STMPE610)

--- a/components/lvgl_esp32_drivers/lvgl_touch/stmpe610.h
+++ b/components/lvgl_esp32_drivers/lvgl_touch/stmpe610.h
@@ -21,6 +21,8 @@ extern "C" {
 #include "lvgl/lvgl.h"
 #endif
 
+#if defined(CONFIG_LV_TOUCH_CONTROLLER_STMPE610)
+
 /*********************
  *      DEFINES
  *********************/
@@ -177,6 +179,8 @@ bool stmpe610_read(lv_indev_drv_t * drv, lv_indev_data_t * data);
 /**********************
  *      MACROS
  **********************/
+
+#endif  // defined(CONFIG_LV_TOUCH_CONTROLLER_STMPE610)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/components/lvgl_esp32_drivers/lvgl_touch/tp_i2c.c
+++ b/components/lvgl_esp32_drivers/lvgl_touch/tp_i2c.c
@@ -21,6 +21,8 @@
 #include <driver/i2c.h>
 #include <esp_log.h>
 
+#if defined(CONFIG_LV_TOUCH_DRIVER_PROTOCOL_I2C)
+
 #define I2C_MASTER_FREQ_HZ 100000                             /* 100kHz*/
 #define I2C_MASTER_TX_BUF_DISABLE 0                           /* I2C master doesn't need buffer */
 #define I2C_MASTER_RX_BUF_DISABLE 0                           /* I2C master doesn't need buffer */
@@ -41,3 +43,5 @@ esp_err_t i2c_master_init(void) {
     i2c_param_config(i2c_master_port, &conf);
     return i2c_driver_install(i2c_master_port, conf.mode, I2C_MASTER_RX_BUF_DISABLE, I2C_MASTER_TX_BUF_DISABLE, 0);
 }
+
+#endif  // defined(CONFIG_LV_TOUCH_DRIVER_PROTOCOL_I2C)

--- a/components/lvgl_esp32_drivers/lvgl_touch/tp_i2c.h
+++ b/components/lvgl_esp32_drivers/lvgl_touch/tp_i2c.h
@@ -26,8 +26,13 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include <sdkconfig.h>
+
+#if defined(CONFIG_LV_TOUCH_DRIVER_PROTOCOL_I2C)
 
 esp_err_t i2c_master_init(void);
+
+#endif  // defined(CONFIG_LV_TOUCH_DRIVER_PROTOCOL_I2C)
 
 #ifdef __cplusplus
 }

--- a/components/lvgl_esp32_drivers/lvgl_touch/tp_spi.c
+++ b/components/lvgl_esp32_drivers/lvgl_touch/tp_spi.c
@@ -16,6 +16,8 @@
 #include "../lvgl_helpers.h"
 #include "../lvgl_spi_conf.h"
 
+#if defined(CONFIG_LV_TOUCH_DRIVER_PROTOCOL_SPI)
+
 /*********************
  *      DEFINES
  *********************/
@@ -107,3 +109,5 @@ void tp_spi_read_reg(uint8_t reg, uint8_t* data, uint8_t byte_count)
 /**********************
  *   STATIC FUNCTIONS
  **********************/
+
+#endif  // defined(CONFIG_LV_TOUCH_DRIVER_PROTOCOL_SPI)

--- a/components/lvgl_esp32_drivers/lvgl_touch/tp_spi.h
+++ b/components/lvgl_esp32_drivers/lvgl_touch/tp_spi.h
@@ -14,7 +14,10 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include <stdint.h>
+#include <sdkconfig.h>
 #include <driver/spi_master.h>
+
+#if defined(CONFIG_LV_TOUCH_DRIVER_PROTOCOL_SPI)
 
 /*********************
  *      DEFINES
@@ -37,6 +40,7 @@ void tp_spi_read_reg(uint8_t reg, uint8_t* data, uint8_t byte_count);
  *      MACROS
  **********************/
 
+#endif  // defined(CONFIG_LV_TOUCH_DRIVER_PROTOCOL_SPI)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/components/lvgl_esp32_drivers/lvgl_touch/xpt2046.c
+++ b/components/lvgl_esp32_drivers/lvgl_touch/xpt2046.c
@@ -13,6 +13,8 @@
 #include "tp_spi.h"
 #include <stddef.h>
 
+#if defined(CONFIG_LV_TOUCH_CONTROLLER_XPT2046)
+
 /*********************
  *      DEFINES
  *********************/
@@ -178,3 +180,5 @@ static void xpt2046_avg(int16_t * x, int16_t * y)
     (*x) = (int32_t)x_sum / avg_last;
     (*y) = (int32_t)y_sum / avg_last;
 }
+
+#endif  // defined(CONFIG_LV_TOUCH_CONTROLLER_XPT2046)

--- a/components/lvgl_esp32_drivers/lvgl_touch/xpt2046.h
+++ b/components/lvgl_esp32_drivers/lvgl_touch/xpt2046.h
@@ -22,6 +22,8 @@ extern "C" {
 #include "lvgl/lvgl.h"
 #endif
 
+#if defined(CONFIG_LV_TOUCH_CONTROLLER_XPT2046)
+
 /*********************
  *      DEFINES
  *********************/
@@ -49,6 +51,8 @@ bool xpt2046_read(lv_indev_drv_t * drv, lv_indev_data_t * data);
 /**********************
  *      MACROS
  **********************/
+
+#endif  // defined(CONFIG_LV_TOUCH_CONTROLLER_XPT2046)
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
This change wraps driver header/source files in the appropriate
constants to effectively make them empty if that driver is not
used in this build.

The ESP-IDF build system is smart enough to conditionally build
source files depending on project settings (see CMakeLists.txt
in drivers folders). PlatformIO is not, and always builds every
file. This change effectively makes those files no-ops
which serves the same purpose and makes this project able to
compile with PlatformIO (and other build systems).

This addresses, but does not entirely fix, issue #220.