### PR TITLE
Revert "Including lv_core/lv_refr.h differently form platformio."

### DIFF
--- a/components/lvgl_esp32_drivers/lvgl_helpers.c
+++ b/components/lvgl_esp32_drivers/lvgl_helpers.c
@@ -18,11 +18,7 @@
 
 #include "driver/i2c.h"
 
-#if defined(PLATFORMIO)
-#include "lv_core/lv_refr.h"
-#else
 #include "lvgl/src/lv_core/lv_refr.h"
-#endif
 
 /*********************
  *      DEFINES


### PR DESCRIPTION
This reverts commit 31c6ed0154600dd9ebe78f3538ed479be8b12aea.

The reverted change enabled a PlatformIO project to build lv_port_esp32
when adding it as a library dependency using the platformio.ini
lib_deps[¹] value. Unfortunately it broke the PlatformIO build when
building this project (i.e. main/main.c). Reverting and hopefully
coming up with a better solution.

[¹]: https://docs.platformio.org/en/latest/projectconf/section_env_library.html#lib-deps