### PR TITLE
Set overwrites main component

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ cmake_minimum_required(VERSION 3.5)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
-set(EXTRA_COMPONENT_DIRS components/lv_port_esp32/components/lv_examples components/lv_port_esp32/components/lvgl components/lv_port_esp32/components/lvgl_esp32_drivers/lvgl_tft components/lv_port_esp32/components/lvgl_esp32_drivers/lvgl_touch components/lv_port_esp32/components/lvgl_esp32_drivers)
+list(APPEND EXTRA_COMPONENT_DIRS components/lv_port_esp32/components/lv_examples components/lv_port_esp32/components/lvgl components/lv_port_esp32/components/lvgl_esp32_drivers/lvgl_tft components/lv_port_esp32/components/lvgl_esp32_drivers/lvgl_touch components/lv_port_esp32/components/lvgl_esp32_drivers)
 
 project(blink)
 ```


### PR DESCRIPTION
Problem:
CMake cannot find the main component when it is configuring. This is cause by the set command overwriting the component list. Appending to the component list is a safer procedure.

Test Setup:
1. Initialize Platformio espidf blink example
2. Follow [these](https://github.com/lvgl/lv_port_esp32#install-this-project-as-a-library-submodule-in-your-own-project) steps from the readme file
3. Observe build errors