### PR TITLE
Fix build ESP-IDF 4.2

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,6 +1,5 @@
 set(SOURCES main.c)
 idf_component_register(SRCS ${SOURCES}
-                    INCLUDE_DIRS .
-                    REQUIRES lvgl_esp32_drivers lvgl_touch lvgl_tft lvgl lv_examples)
+                    INCLUDE_DIRS .)
 
 target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_LVGL_H_INCLUDE_SIMPLE")


### PR DESCRIPTION
This fixes a compilation issue with (at least) `ESP-IDF 4.2`, as with original code libraries were duplicated in `LINK_LIBRARIES` targetand the "second copy" of `lv_examples.a` was placed after `lvgl.a`, causing build failure with lots of `undefined references`) 