### PR TITLE
Support make build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,11 @@
 PROJECT_NAME := lvgl-demo
 
 # Add new components (source folders)
-EXTRA_COMPONENT_DIRS := components/lvgl_esp32_drivers/lvgl_tft
-EXTRA_COMPONENT_DIRS += components/lvgl_esp32_drivers/lvgl_touch
+
+# Any paths in this makefile should be absolute paths.
+EXTRA_COMPONENT_DIRS := $(PROJECT_PATH)/components/lvgl_esp32_drivers/lvgl_tft
+EXTRA_COMPONENT_DIRS += $(PROJECT_PATH)/components/lvgl_esp32_drivers/lvgl_touch
+
 # Must be before include $(IDF_PATH)/make/project.mk
 # $(PROJECT_PATH)/xxx didn't work -> use $(abspath xxx) instead
 


### PR DESCRIPTION
@tore-espressif With this PR we're trying to improve (be able to compile the project) using the make build system.
According to [this](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system-legacy.html#optional-project-variables), paths in the main Makefile must be absolute, I've fixed that in this commit b2553d03754ff4d01d58f86d055ef04904c47844