### PR TITLE
Remove Extra component dirs definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 
 if (NOT DEFINED PROJECT_NAME)
     include($ENV{IDF_PATH}/tools/cmake/project.cmake)
- 
-    list(APPEND EXTRA_COMPONENT_DIRS components/lvgl_esp32_drivers components/lvgl_esp32_drivers/lvgl_touch components/lvgl_esp32_drivers/lvgl_tft)
-
     project(lvgl-demo)
-endif (NOT DEFINED PROJECT_NAME)
+else()
+    message(FATAL_ERROR "LV PORT ESP32: This must be a project's main CMakeLists.txt.")
+endif()

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,4 @@
 #
 
 PROJECT_NAME := lvgl-demo
-
-# Add new components (source folders)
-EXTRA_COMPONENT_DIRS := components/lvgl_esp32_drivers/lvgl_tft
-EXTRA_COMPONENT_DIRS += components/lvgl_esp32_drivers/lvgl_touch
-# Must be before include $(IDF_PATH)/make/project.mk
-# $(PROJECT_PATH)/xxx didn't work -> use $(abspath xxx) instead
-
 include $(IDF_PATH)/make/project.mk
-

--- a/components/lv_examples/CMakeLists.txt
+++ b/components/lv_examples/CMakeLists.txt
@@ -6,4 +6,6 @@ idf_component_register(SRCS ${SOURCES}
                        INCLUDE_DIRS .
                        REQUIRES lvgl)
 
+else()
+    message(FATAL_ERROR "LVGL LV examples: ESP_PLATFORM is not defined. Try reinstalling ESP-IDF.")
 endif()

--- a/components/lv_examples/component.mk
+++ b/components/lv_examples/component.mk
@@ -2,7 +2,7 @@
 # Component Makefile
 #
 
-CFLAGS += -DLV_CONF_INCLUDE_SIMPLE
+CFLAGS += -DLV_LVGL_H_INCLUDE_SIMPLE
 
 COMPONENT_SRCDIRS := lv_examples           \
     lv_examples/src/lv_demo_benchmark      \

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,5 +1,1 @@
-set(SOURCES main.c)
-idf_component_register(SRCS ${SOURCES}
-                    INCLUDE_DIRS .)
-
-target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DLV_LVGL_H_INCLUDE_SIMPLE")
+idf_component_register(SRCS main.c)

--- a/main/component.mk
+++ b/main/component.mk
@@ -3,5 +3,4 @@
 #
 # (Uses default behaviour of compiling all source files in directory, adding 'include' to include path.)
 
-CFLAGS += -DLV_CONF_INCLUDE_SIMPLE
-CFLAGS += -DLV_LVGL_H_INCLUDE_SIMPLE
+CFLAGS+= -DLV_LVGL_H_INCLUDE_SIMPLE

--- a/main/main.c
+++ b/main/main.c
@@ -21,7 +21,7 @@
 #include "driver/gpio.h"
 
 /* Littlevgl specific */
-#ifdef LV_CONF_INCLUDE_SIMPLE
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
 #include "lvgl.h"
 #else
 #include "lvgl/lvgl.h"


### PR DESCRIPTION
Latest `lvgl_esp32_drivers` changes its component structure. This project has to be updated for it.

TODOs:
- [x] Merge https://github.com/lvgl/lvgl_esp32_drivers/pull/42
- [x] Update lvgl_esp32_drivers submodule in this PR
- [x] Test on linux - Make
- [x] Test on linux - CMake