### PR TITLE
Add esp-build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: 'build'
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        idf_ver: ["v4.1", "v4.2", "v4.3"]
+        idf_target: ["esp32"]
+        include:
+          - idf_ver: "v4.2"
+            idf_target: esp32s2
+            # TODO: enable C3 build
+          #- idf_ver: "v4.3"
+          #  idf_target: esp32c3
+    runs-on: ubuntu-20.04
+    container: espressif/idf:release-${{ matrix.idf_ver }}
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: recursive
+      - name: Build for ESP32
+        env:
+          IDF_TARGET: ${{ matrix.idf_target }}
+        shell: bash
+        run: |
+          . ${IDF_PATH}/export.sh
+          idf.py build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
         with:
-          submodules: recursive
+          submodules: true
       - name: Build for ESP32
         env:
           IDF_TARGET: ${{ matrix.idf_target }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
             # TODO: enable C3 build
           #- idf_ver: "v4.3"
           #  idf_target: esp32c3
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: espressif/idf:release-${{ matrix.idf_ver }}
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
This is a preview how to run ESP-IDF build from Github Actions.

It's a 'preview' because there are few limitations:

- ~~We still need `lv_port_esp32` repo to run build action, because `lvgl_esp32_drivers` doesn't contain examples that can be built into a full app~~ There are examples and build action now in `lvgl_esp32_drivers`
- ~~Currently only default example configuration is built. Thus only ILI9341 driver is compiled. Ultimately we need to compile all drivers in one build action~~. `master` of `lvgl_esp32_drivers` builds all drivers

Above-mentioned issues will be addressed in https://github.com/lvgl/lvgl_esp32_drivers/issues/72